### PR TITLE
test: add test suites for browse-cli and search-cli packages

### DIFF
--- a/packages/browse-cli/tests/test_browse_cmd.py
+++ b/packages/browse-cli/tests/test_browse_cmd.py
@@ -1,0 +1,143 @@
+"""Tests for browse CLI command."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from typer.testing import CliRunner
+
+from ra_mcp_browse_cli.app import browse_app
+from ra_mcp_browse_lib.models import BrowseResult, PageContext
+from ra_mcp_oai_pmh_lib import OAIPMHMetadata
+
+
+REFERENCE_CODE = "SE/RA/310187/1"
+MANIFEST_ID = "R0001203"
+
+runner = CliRunner()
+
+
+def _make_page_context(page_number: int = 1, text: str = "transcribed text") -> PageContext:
+    return PageContext(
+        page_number=page_number,
+        page_id=str(page_number),
+        reference_code=REFERENCE_CODE,
+        full_text=text,
+        alto_url=f"https://example.com/alto/{page_number}.xml",
+        image_url=f"https://example.com/image/{page_number}.jpg",
+        bildvisning_url=f"https://example.com/bild/{page_number}",
+    )
+
+
+def _make_browse_result(
+    num_pages: int = 2,
+    metadata: OAIPMHMetadata | None = None,
+) -> BrowseResult:
+    contexts = [_make_page_context(i + 1) for i in range(num_pages)]
+    return BrowseResult(
+        contexts=contexts,
+        reference_code=REFERENCE_CODE,
+        pages_requested="1-20",
+        manifest_id=MANIFEST_ID,
+        oai_metadata=metadata or OAIPMHMetadata(identifier=REFERENCE_CODE, title="Test"),
+    )
+
+
+def _patch_browse(return_value: BrowseResult):
+    return patch(
+        "ra_mcp_browse_cli.browse_cmd.BrowseOperations",
+        return_value=AsyncMock(browse_document=AsyncMock(return_value=return_value)),
+    )
+
+
+def test_browse_success():
+    result_data = _make_browse_result(num_pages=2)
+    with _patch_browse(result_data):
+        result = runner.invoke(browse_app, [REFERENCE_CODE])
+    assert result.exit_code == 0
+    assert "Browsing document" in result.output
+
+
+def test_browse_with_pages_option():
+    result_data = _make_browse_result(num_pages=3)
+    with _patch_browse(result_data):
+        result = runner.invoke(browse_app, [REFERENCE_CODE, "--pages", "1-3"])
+    assert result.exit_code == 0
+
+
+def test_browse_with_page_option():
+    result_data = _make_browse_result(num_pages=1)
+    with _patch_browse(result_data):
+        result = runner.invoke(browse_app, [REFERENCE_CODE, "--page", "5"])
+    assert result.exit_code == 0
+
+
+def test_browse_page_takes_precedence_over_pages():
+    result_data = _make_browse_result(num_pages=1)
+    with _patch_browse(result_data) as mock_cls:
+        runner.invoke(browse_app, [REFERENCE_CODE, "--pages", "1-10", "--page", "5"])
+    mock_cls.return_value.browse_document.assert_called_once()
+    call_kwargs = mock_cls.return_value.browse_document.call_args
+    assert call_kwargs.kwargs.get("pages") == "5" or call_kwargs[1].get("pages") == "5"
+
+
+def test_browse_with_search_term():
+    result_data = _make_browse_result(num_pages=1)
+    with _patch_browse(result_data):
+        result = runner.invoke(browse_app, [REFERENCE_CODE, "--search-term", "trolldom"])
+    assert result.exit_code == 0
+
+
+def test_browse_with_log_flag():
+    result_data = _make_browse_result(num_pages=1)
+    with _patch_browse(result_data):
+        result = runner.invoke(browse_app, [REFERENCE_CODE, "--log"])
+    assert result.exit_code == 0
+    assert "logging enabled" in result.output.lower()
+
+
+def test_browse_with_show_links():
+    result_data = _make_browse_result(num_pages=1)
+    with _patch_browse(result_data):
+        result = runner.invoke(browse_app, [REFERENCE_CODE, "--show-links"])
+    assert result.exit_code == 0
+
+
+def test_browse_no_pages_found():
+    empty_result = BrowseResult(
+        contexts=[],
+        reference_code=REFERENCE_CODE,
+        pages_requested="1-20",
+        oai_metadata=None,
+    )
+    with _patch_browse(empty_result):
+        result = runner.invoke(browse_app, [REFERENCE_CODE])
+    assert result.exit_code == 1
+    assert "No pages found" in result.output
+
+
+def test_browse_non_digitised_material():
+    non_digitised = BrowseResult(
+        contexts=[],
+        reference_code=REFERENCE_CODE,
+        pages_requested="1-20",
+        oai_metadata=OAIPMHMetadata(identifier=REFERENCE_CODE, title="Old doc"),
+    )
+    with _patch_browse(non_digitised):
+        result = runner.invoke(browse_app, [REFERENCE_CODE])
+    assert result.exit_code == 0
+
+
+def test_browse_operation_error():
+    with patch(
+        "ra_mcp_browse_cli.browse_cmd.BrowseOperations",
+        return_value=AsyncMock(browse_document=AsyncMock(side_effect=RuntimeError("API down"))),
+    ):
+        result = runner.invoke(browse_app, [REFERENCE_CODE])
+    assert result.exit_code == 1
+    assert "Browse failed" in result.output
+
+
+def test_browse_no_args_shows_help():
+    result = runner.invoke(browse_app, [])
+    assert result.exit_code == 2
+    assert "Usage" in result.output or "reference" in result.output.lower()

--- a/packages/browse-cli/tests/test_browse_formatter.py
+++ b/packages/browse-cli/tests/test_browse_formatter.py
@@ -1,0 +1,427 @@
+"""Tests for browse-cli RichConsoleFormatter."""
+
+import pytest
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from ra_mcp_browse_lib.models import BrowseResult, PageContext
+from ra_mcp_oai_pmh_lib import OAIPMHMetadata
+from ra_mcp_search_lib.models import (
+    Metadata,
+    PageInfo,
+    RecordsResponse,
+    SearchRecord,
+    SearchResult,
+    Snippet,
+    TranscribedText,
+)
+
+from ra_mcp_browse_cli.formatter import RichConsoleFormatter
+
+
+REFERENCE_CODE = "SE/RA/310187/1"
+MANIFEST_ID = "R0001203"
+
+
+def _make_formatter() -> RichConsoleFormatter:
+    return RichConsoleFormatter(Console(force_terminal=True, width=120))
+
+
+def _make_page_context(
+    page_number: int = 1,
+    text: str = "some transcribed text",
+    ref_code: str = REFERENCE_CODE,
+) -> PageContext:
+    return PageContext(
+        page_number=page_number,
+        page_id=str(page_number),
+        reference_code=ref_code,
+        full_text=text,
+        alto_url=f"https://sok.riksarkivet.se/dokument/alto/{MANIFEST_ID}_{page_number:05d}.xml",
+        image_url=f"https://lbiiif.riksarkivet.se/arkis!{MANIFEST_ID}_{page_number:05d}/full/max/0/default.jpg",
+        bildvisning_url=f"https://sok.riksarkivet.se/bildvisning/{MANIFEST_ID}_{page_number:05d}",
+    )
+
+
+def _make_metadata(**overrides) -> OAIPMHMetadata:
+    defaults = dict(
+        identifier=REFERENCE_CODE,
+        title="Test Document",
+        unitdate="1700-1800",
+        repository="Riksarkivet",
+    )
+    defaults.update(overrides)
+    return OAIPMHMetadata(**defaults)
+
+
+def _make_browse_result(
+    num_pages: int = 2,
+    metadata: OAIPMHMetadata | None = None,
+    contexts: list[PageContext] | None = None,
+) -> BrowseResult:
+    if contexts is None:
+        contexts = [_make_page_context(i + 1) for i in range(num_pages)]
+    return BrowseResult(
+        contexts=contexts,
+        reference_code=REFERENCE_CODE,
+        pages_requested="1-20",
+        manifest_id=MANIFEST_ID,
+        oai_metadata=metadata,
+    )
+
+
+def _make_search_result(
+    num_records: int = 1,
+    keyword: str = "trolldom",
+    total_hits: int = 10,
+    offset: int = 0,
+) -> SearchResult:
+    items = [
+        SearchRecord(
+            id=f"SE/RA/TEST/{i}",
+            objectType="Record",
+            type="Volume",
+            caption=f"Test Record {i}",
+            metadata=Metadata(referenceCode=f"SE/RA/TEST/{i}"),
+            transcribedText=TranscribedText(
+                numTotal=2,
+                snippets=[
+                    Snippet(text=f"snippet with {keyword}", score=0.9, pages=[PageInfo(id=f"_{j:05d}")])
+                    for j in range(1, 3)
+                ],
+            ),
+        )
+        for i in range(num_records)
+    ]
+    response = RecordsResponse(totalHits=total_hits, items=items, hits=num_records, offset=offset)
+    return SearchResult(response=response, transcribed_text=keyword, limit=50, offset=offset)
+
+
+# ── format_text ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text,style,expected",
+    [
+        pytest.param("hello", "bold", "[bold]hello[/bold]", id="with-style"),
+        pytest.param("plain", "", "plain", id="no-style"),
+    ],
+)
+def test_format_text(text, style, expected):
+    assert _make_formatter().format_text(text, style) == expected
+
+
+# ── format_table ─────────────────────────────────────────────────────────
+
+
+def test_format_table_returns_table():
+    table = _make_formatter().format_table(["A", "B"], [["1", "2"]], "Title")
+    assert isinstance(table, Table)
+
+
+def test_format_table_no_title():
+    table = _make_formatter().format_table(["Col"], [["val"]])
+    assert isinstance(table, Table)
+
+
+# ── format_panel ─────────────────────────────────────────────────────────
+
+
+def test_format_panel_returns_panel():
+    panel = _make_formatter().format_panel("content", "title", "blue")
+    assert isinstance(panel, Panel)
+
+
+def test_format_panel_defaults():
+    panel = _make_formatter().format_panel("content")
+    assert isinstance(panel, Panel)
+    assert panel.border_style == "green"
+
+
+# ── highlight_search_keyword ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text,keyword,expected_fragment",
+    [
+        pytest.param(
+            "found **trolldom** here",
+            "trolldom",
+            "[bold yellow underline]trolldom[/bold yellow underline]",
+            id="api-markers-converted",
+        ),
+        pytest.param(
+            "text with Trolldom inside",
+            "trolldom",
+            "[bold yellow underline]Trolldom[/bold yellow underline]",
+            id="keyword-case-insensitive",
+        ),
+        pytest.param(
+            "no markers here",
+            "",
+            "no markers here",
+            id="empty-keyword-unchanged",
+        ),
+        pytest.param(
+            "no match at all",
+            "xyz",
+            "no match at all",
+            id="keyword-not-found",
+        ),
+    ],
+)
+def test_highlight_search_keyword(text, keyword, expected_fragment):
+    result = _make_formatter().highlight_search_keyword(text, keyword)
+    assert expected_fragment in result
+
+
+def test_highlight_api_markers_take_precedence():
+    result = _make_formatter().highlight_search_keyword("**word** and more", "more")
+    assert "[bold yellow underline]word[/bold yellow underline]" in result
+    assert "[bold yellow underline]more[/bold yellow underline]" not in result
+
+
+# ── format_page_context_panel ────────────────────────────────────────────
+
+
+def test_format_page_context_panel_returns_panel():
+    ctx = _make_page_context(5, "page five text")
+    panel = _make_formatter().format_page_context_panel(ctx)
+    assert isinstance(panel, Panel)
+
+
+def test_format_page_context_panel_with_highlight():
+    ctx = _make_page_context(1, "text with keyword here")
+    panel = _make_formatter().format_page_context_panel(ctx, highlight_term="keyword")
+    assert isinstance(panel, Panel)
+
+
+# ── format_search_results ───────────────────────────────────────────────
+
+
+def test_format_search_results_returns_table():
+    result = _make_search_result(num_records=2)
+    table = _make_formatter().format_search_results(result)
+    assert isinstance(table, Table)
+
+
+def test_format_search_results_empty():
+    result = _make_search_result(num_records=0, total_hits=0)
+    msg = _make_formatter().format_search_results(result)
+    assert isinstance(msg, str)
+    assert "trolldom" in msg
+
+
+def test_format_search_results_respects_max_display():
+    result = _make_search_result(num_records=5, total_hits=5)
+    table = _make_formatter().format_search_results(result, max_display=2)
+    assert isinstance(table, Table)
+    assert table.row_count == 2
+
+
+# ── format_search_summary_stats ─────────────────────────────────────────
+
+
+def test_format_search_summary_stats_basic():
+    lines = _make_formatter().format_search_summary_stats(
+        snippet_count=10, records_count=5, total_hits=5, offset=0
+    )
+    assert any("10" in line for line in lines)
+    assert any("5" in line for line in lines)
+
+
+def test_format_search_summary_stats_with_pagination():
+    lines = _make_formatter().format_search_summary_stats(
+        snippet_count=10, records_count=5, total_hits=100, offset=50
+    )
+    assert any("100" in line for line in lines)
+    assert any("50" in line for line in lines)
+
+
+def test_format_search_summary_stats_no_extra_when_all_shown():
+    lines = _make_formatter().format_search_summary_stats(
+        snippet_count=3, records_count=3, total_hits=3, offset=0
+    )
+    assert len(lines) == 1
+
+
+# ── format_browse_example ────────────────────────────────────────────────
+
+
+def test_format_browse_example_with_snippets():
+    result = _make_search_result(num_records=1)
+    lines = _make_formatter().format_browse_example(result.items, "trolldom")
+    assert len(lines) == 2
+    assert "ra browse" in lines[1]
+    assert "trolldom" in lines[1]
+
+
+def test_format_browse_example_empty_documents():
+    lines = _make_formatter().format_browse_example([], "test")
+    assert lines == []
+
+
+def test_format_browse_example_no_snippets():
+    doc = SearchRecord(
+        id="SE/RA/1",
+        objectType="Record",
+        metadata=Metadata(referenceCode="SE/RA/1"),
+    )
+    lines = _make_formatter().format_browse_example([doc], "test")
+    assert lines == []
+
+
+# ── format_remaining_documents ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "total,displayed,expect_message",
+    [
+        pytest.param(30, 20, True, id="more-remaining"),
+        pytest.param(10, 20, False, id="all-shown"),
+        pytest.param(5, 5, False, id="exact-match"),
+    ],
+)
+def test_format_remaining_documents(total, displayed, expect_message):
+    msg = _make_formatter().format_remaining_documents(total, displayed)
+    if expect_message:
+        assert "10 more" in msg
+    else:
+        assert msg == ""
+
+
+# ── format_no_results_message ────────────────────────────────────────────
+
+
+def test_no_results_message_at_offset_zero():
+    result = _make_search_result(num_records=0, total_hits=0, offset=0)
+    msg = _make_formatter().format_no_results_message(result)
+    assert "No results found" in msg
+    assert "trolldom" in msg
+
+
+def test_no_results_message_at_offset_positive():
+    result = _make_search_result(num_records=0, total_hits=50, offset=50)
+    msg = _make_formatter().format_no_results_message(result)
+    assert "No more results" in msg
+    assert "50" in msg
+
+
+# ── format_browse_results ───────────────────────────────────────────────
+
+
+def test_format_browse_results_with_pages():
+    browse = _make_browse_result(num_pages=3, metadata=_make_metadata())
+    output = _make_formatter().format_browse_results(browse)
+    assert any(isinstance(item, Panel) for item in output)
+    assert any("Successfully loaded 3 pages" in str(item) for item in output if isinstance(item, str))
+
+
+def test_format_browse_results_no_success_message():
+    browse = _make_browse_result(num_pages=1)
+    output = _make_formatter().format_browse_results(browse, show_success_message=False)
+    assert not any("Successfully loaded" in str(item) for item in output if isinstance(item, str))
+
+
+def test_format_browse_results_with_highlight():
+    browse = _make_browse_result(
+        contexts=[_make_page_context(1, "text with keyword here")],
+        metadata=_make_metadata(),
+    )
+    output = _make_formatter().format_browse_results(browse, highlight_term="keyword")
+    assert any(isinstance(item, Panel) for item in output)
+
+
+def test_format_browse_results_with_show_links():
+    browse = _make_browse_result(num_pages=1, metadata=_make_metadata())
+    output = _make_formatter().format_browse_results(browse, show_links=True)
+    assert any(isinstance(item, Panel) for item in output)
+
+
+def test_format_browse_results_groups_by_reference_code():
+    ctx_a1 = _make_page_context(1, ref_code="SE/RA/A")
+    ctx_a2 = _make_page_context(2, ref_code="SE/RA/A")
+    ctx_b1 = _make_page_context(1, ref_code="SE/RA/B")
+    browse = _make_browse_result(contexts=[ctx_a1, ctx_a2, ctx_b1])
+    output = _make_formatter().format_browse_results(browse)
+    panels = [item for item in output if isinstance(item, Panel)]
+    assert len(panels) == 2
+
+
+def test_format_browse_results_sorts_pages():
+    ctx3 = _make_page_context(3)
+    ctx1 = _make_page_context(1)
+    ctx2 = _make_page_context(2)
+    browse = _make_browse_result(contexts=[ctx3, ctx1, ctx2])
+    output = _make_formatter().format_browse_results(browse)
+    assert any(isinstance(item, Panel) for item in output)
+
+
+def test_format_browse_results_empty_page_text():
+    ctx = _make_page_context(1, text="")
+    browse = _make_browse_result(contexts=[ctx])
+    output = _make_formatter().format_browse_results(browse)
+    assert any(isinstance(item, Panel) for item in output)
+
+
+# ── _format_non_digitised_panel ──────────────────────────────────────────
+
+
+def test_format_non_digitised_panel():
+    metadata = _make_metadata(
+        nad_link="https://sok.riksarkivet.se/bildvisning/R0001203",
+        description="A detailed description",
+    )
+    browse = BrowseResult(
+        contexts=[],
+        reference_code=REFERENCE_CODE,
+        pages_requested="1-20",
+        oai_metadata=metadata,
+    )
+    output = _make_formatter().format_browse_results(browse)
+    assert any("not digitised" in str(item).lower() for item in output)
+    assert any(isinstance(item, Panel) for item in output)
+
+
+def test_format_non_digitised_panel_truncates_long_description():
+    metadata = _make_metadata(description="x" * 500)
+    browse = BrowseResult(
+        contexts=[],
+        reference_code=REFERENCE_CODE,
+        pages_requested="1-20",
+        oai_metadata=metadata,
+    )
+    output = _make_formatter().format_browse_results(browse)
+    assert any(isinstance(item, Panel) for item in output)
+
+
+def test_format_non_digitised_no_metadata():
+    browse = BrowseResult(
+        contexts=[],
+        reference_code=REFERENCE_CODE,
+        pages_requested="1-20",
+        oai_metadata=None,
+    )
+    output = _make_formatter().format_browse_results(browse)
+    assert output == []
+
+
+# ── _format_group_metadata ──────────────────────────────────────────────
+
+
+def test_format_group_metadata_included_in_browse():
+    metadata = _make_metadata(
+        unitid="VOL-1",
+        description="Short desc",
+        nad_link="https://example.com/nad",
+    )
+    browse = _make_browse_result(num_pages=1, metadata=metadata)
+    output = _make_formatter().format_browse_results(browse)
+    assert any(isinstance(item, Panel) for item in output)
+
+
+def test_format_browse_results_no_metadata():
+    browse = _make_browse_result(num_pages=1, metadata=None)
+    output = _make_formatter().format_browse_results(browse)
+    assert any(isinstance(item, Panel) for item in output)

--- a/packages/search-cli/tests/test_search_cmd.py
+++ b/packages/search-cli/tests/test_search_cmd.py
@@ -1,0 +1,133 @@
+"""Tests for search CLI command."""
+
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+from ra_mcp_search_cli.app import search_app
+from ra_mcp_search_lib.models import (
+    Metadata,
+    PageInfo,
+    RecordsResponse,
+    SearchRecord,
+    SearchResult,
+    Snippet,
+    TranscribedText,
+)
+
+
+runner = CliRunner()
+
+
+def _make_search_result(
+    keyword: str = "trolldom",
+    num_records: int = 2,
+    total_hits: int = 10,
+    offset: int = 0,
+    limit: int = 50,
+) -> SearchResult:
+    items = [
+        SearchRecord(
+            id=f"SE/RA/TEST/{i}",
+            objectType="Record",
+            type="Volume",
+            caption=f"Test Record {i}",
+            metadata=Metadata(referenceCode=f"SE/RA/TEST/{i}"),
+            transcribedText=TranscribedText(
+                numTotal=3,
+                snippets=[
+                    Snippet(text=f"snippet with {keyword}", score=0.9, pages=[PageInfo(id="_00001")])
+                ],
+            ),
+        )
+        for i in range(num_records)
+    ]
+    response = RecordsResponse(totalHits=total_hits, items=items, hits=num_records, offset=offset)
+    return SearchResult(response=response, transcribed_text=keyword, limit=limit, offset=offset)
+
+
+def _patch_search(return_value: SearchResult):
+    return patch(
+        "ra_mcp_search_cli.search_cmd.SearchOperations",
+        return_value=AsyncMock(search=AsyncMock(return_value=return_value)),
+    )
+
+
+def test_search_success():
+    result_data = _make_search_result()
+    with _patch_search(result_data):
+        result = runner.invoke(search_app, ["trolldom"])
+    assert result.exit_code == 0
+
+
+def test_search_with_limit():
+    result_data = _make_search_result()
+    with _patch_search(result_data):
+        result = runner.invoke(search_app, ["trolldom", "--limit", "100"])
+    assert result.exit_code == 0
+
+
+def test_search_with_max_display():
+    result_data = _make_search_result(num_records=5)
+    with _patch_search(result_data):
+        result = runner.invoke(search_app, ["trolldom", "--max-display", "2"])
+    assert result.exit_code == 0
+
+
+def test_search_with_max_hits_per_vol():
+    result_data = _make_search_result()
+    with _patch_search(result_data):
+        result = runner.invoke(search_app, ["trolldom", "--max-hits-per-vol", "1"])
+    assert result.exit_code == 0
+
+
+def test_search_text_mode():
+    result_data = _make_search_result()
+    with _patch_search(result_data):
+        result = runner.invoke(search_app, ["trolldom", "--text"])
+    assert result.exit_code == 0
+
+
+def test_search_include_all_materials_switches_to_text():
+    result_data = _make_search_result()
+    with _patch_search(result_data):
+        result = runner.invoke(search_app, ["Stockholm", "--include-all-materials"])
+    assert result.exit_code == 0
+    assert "switching to --text" in result.output.lower() or "automatically switching" in result.output.lower()
+
+
+def test_search_with_log_flag():
+    result_data = _make_search_result()
+    with _patch_search(result_data):
+        result = runner.invoke(search_app, ["trolldom", "--log"])
+    assert result.exit_code == 0
+    assert "logging enabled" in result.output.lower()
+
+
+def test_search_no_results():
+    result_data = _make_search_result(num_records=0, total_hits=0)
+    with _patch_search(result_data):
+        result = runner.invoke(search_app, ["nonexistent"])
+    assert result.exit_code == 0
+
+
+def test_search_operation_error():
+    with patch(
+        "ra_mcp_search_cli.search_cmd.SearchOperations",
+        return_value=AsyncMock(search=AsyncMock(side_effect=RuntimeError("API down"))),
+    ):
+        result = runner.invoke(search_app, ["trolldom"])
+    assert result.exit_code == 1
+    assert "Search failed" in result.output
+
+
+def test_search_no_args_shows_help():
+    result = runner.invoke(search_app, [])
+    assert result.exit_code == 2
+    assert "Usage" in result.output or "keyword" in result.output.lower()
+
+
+def test_search_help_flag():
+    result = runner.invoke(search_app, ["--help"])
+    assert result.exit_code == 0
+    assert "keyword" in result.output.lower() or "search" in result.output.lower()

--- a/packages/search-cli/tests/test_search_formatter.py
+++ b/packages/search-cli/tests/test_search_formatter.py
@@ -1,0 +1,416 @@
+"""Tests for search-cli RichConsoleFormatter."""
+
+import pytest
+from rich.console import Console
+from rich.panel import Panel
+from rich.table import Table
+
+from ra_mcp_search_lib.models import (
+    DocumentLinks,
+    GenericReference,
+    Metadata,
+    PageInfo,
+    RecordsResponse,
+    SearchRecord,
+    SearchResult,
+    Snippet,
+    TranscribedText,
+)
+
+from ra_mcp_search_cli.formatter import RichConsoleFormatter
+
+
+def _make_formatter() -> RichConsoleFormatter:
+    return RichConsoleFormatter(Console(force_terminal=True, width=120))
+
+
+def _make_record(
+    record_id: str = "SE/RA/TEST/1",
+    ref_code: str = "SE/RA/TEST/1",
+    caption: str = "Test Record",
+    num_snippets: int = 2,
+    num_total: int = 5,
+    institution: str = "Riksarkivet",
+    date: str | None = "1700-1800",
+    keyword: str = "trolldom",
+    object_type: str = "Record",
+    record_type: str | None = "Volume",
+    hierarchy: list[GenericReference] | None = None,
+    provenance: list[GenericReference] | None = None,
+    note: str | None = None,
+    links: DocumentLinks | None = None,
+) -> SearchRecord:
+    snippets = [
+        Snippet(
+            text=f"snippet {j} with {keyword}",
+            score=0.9 - j * 0.1,
+            pages=[PageInfo(id=f"_{j:05d}")],
+        )
+        for j in range(1, num_snippets + 1)
+    ]
+    return SearchRecord(
+        id=record_id,
+        objectType=object_type,
+        type=record_type,
+        caption=caption,
+        metadata=Metadata(
+            referenceCode=ref_code,
+            date=date,
+            archivalInstitution=[GenericReference(caption=institution)] if institution else None,
+            hierarchy=hierarchy,
+            provenance=provenance,
+            note=note,
+        ),
+        transcribedText=TranscribedText(numTotal=num_total, snippets=snippets),
+        _links=links,
+    )
+
+
+def _make_search_result(
+    records: list[SearchRecord] | None = None,
+    keyword: str = "trolldom",
+    total_hits: int = 10,
+    offset: int = 0,
+    limit: int = 50,
+) -> SearchResult:
+    if records is None:
+        records = [_make_record(keyword=keyword)]
+    response = RecordsResponse(totalHits=total_hits, items=records, hits=len(records), offset=offset)
+    return SearchResult(response=response, transcribed_text=keyword, limit=limit, offset=offset)
+
+
+# ── format_text ──────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text,style,expected",
+    [
+        pytest.param("hello", "bold", "[bold]hello[/bold]", id="with-style"),
+        pytest.param("plain", "", "plain", id="no-style"),
+    ],
+)
+def test_format_text(text, style, expected):
+    assert _make_formatter().format_text(text, style) == expected
+
+
+# ── format_table ─────────────────────────────────────────────────────────
+
+
+def test_format_table_returns_table():
+    table = _make_formatter().format_table(["A", "B"], [["1", "2"]], "Title")
+    assert isinstance(table, Table)
+
+
+# ── format_panel ─────────────────────────────────────────────────────────
+
+
+def test_format_panel_returns_panel():
+    panel = _make_formatter().format_panel("content", "title", "blue")
+    assert isinstance(panel, Panel)
+
+
+def test_format_panel_defaults():
+    panel = _make_formatter().format_panel("content")
+    assert panel.border_style == "green"
+
+
+# ── highlight_search_keyword ─────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text,keyword,expected_fragment",
+    [
+        pytest.param(
+            "found **trolldom** here",
+            "trolldom",
+            "[bold yellow underline]trolldom[/bold yellow underline]",
+            id="api-markers-converted",
+        ),
+        pytest.param(
+            "text with Trolldom inside",
+            "trolldom",
+            "[bold yellow underline]Trolldom[/bold yellow underline]",
+            id="keyword-case-insensitive",
+        ),
+        pytest.param(
+            "nothing to see",
+            "",
+            "nothing to see",
+            id="empty-keyword-unchanged",
+        ),
+        pytest.param(
+            "no match here",
+            "xyz",
+            "no match here",
+            id="keyword-not-found",
+        ),
+    ],
+)
+def test_highlight_search_keyword(text, keyword, expected_fragment):
+    result = _make_formatter().highlight_search_keyword(text, keyword)
+    assert expected_fragment in result
+
+
+def test_highlight_api_markers_take_precedence_over_keyword():
+    result = _make_formatter().highlight_search_keyword("**word** and more", "more")
+    assert "[bold yellow underline]word[/bold yellow underline]" in result
+    assert "[bold yellow underline]more[/bold yellow underline]" not in result
+
+
+# ── _build_institution_column ────────────────────────────────────────────
+
+
+def test_institution_column_with_institution():
+    fmt = _make_formatter()
+    doc = _make_record(institution="Riksarkivet")
+    col = fmt._build_institution_column(doc)
+    assert "Riksarkivet" in col
+
+
+def test_institution_column_without_institution():
+    fmt = _make_formatter()
+    doc = _make_record(institution="")
+    col = fmt._build_institution_column(doc)
+    assert "SE/RA/TEST/1" in col
+
+
+def test_institution_column_shows_total_hits():
+    fmt = _make_formatter()
+    doc = _make_record(num_snippets=2, num_total=10)
+    col = fmt._build_institution_column(doc)
+    assert "2 hits shown (10 total)" in col
+
+
+def test_institution_column_exact_hits():
+    fmt = _make_formatter()
+    doc = _make_record(num_snippets=3, num_total=3)
+    col = fmt._build_institution_column(doc)
+    assert "3 hits found" in col
+
+
+def test_institution_column_single_hit():
+    fmt = _make_formatter()
+    doc = _make_record(num_snippets=1, num_total=1)
+    col = fmt._build_institution_column(doc)
+    assert "1 hit found" in col
+
+
+def test_institution_column_with_date():
+    fmt = _make_formatter()
+    doc = _make_record(date="1750")
+    col = fmt._build_institution_column(doc)
+    assert "1750" in col
+
+
+def test_institution_column_no_date():
+    fmt = _make_formatter()
+    doc = _make_record(date=None)
+    col = fmt._build_institution_column(doc)
+    assert "📅" not in col
+
+
+def test_institution_column_metadata_match():
+    doc = SearchRecord(
+        id="SE/RA/1",
+        objectType="Record",
+        metadata=Metadata(referenceCode="SE/RA/1"),
+    )
+    col = _make_formatter()._build_institution_column(doc)
+    assert "Metadata match" in col
+
+
+# ── _build_content_column ────────────────────────────────────────────────
+
+
+def test_content_column_with_title():
+    fmt = _make_formatter()
+    doc = _make_record(caption="Important Document")
+    col = fmt._build_content_column(doc, "trolldom")
+    assert "Important Document" in col
+
+
+def test_content_column_no_title():
+    fmt = _make_formatter()
+    doc = _make_record(caption=None)
+    col = fmt._build_content_column(doc, "test")
+    assert "(No title)" in col
+
+
+def test_content_column_object_type():
+    fmt = _make_formatter()
+    doc = _make_record(object_type="Record", record_type="Volume")
+    col = fmt._build_content_column(doc, "test")
+    assert "Record" in col
+    assert "Volume" in col
+
+
+def test_content_column_with_hierarchy():
+    fmt = _make_formatter()
+    doc = _make_record(hierarchy=[
+        GenericReference(caption="Level 1"),
+        GenericReference(caption="Level 2"),
+    ])
+    col = fmt._build_content_column(doc, "test")
+    assert "Level 1" in col
+
+
+def test_content_column_with_provenance():
+    fmt = _make_formatter()
+    doc = _make_record(provenance=[GenericReference(caption="Creator", date="1700")])
+    col = fmt._build_content_column(doc, "test")
+    assert "Creator" in col
+    assert "1700" in col
+
+
+def test_content_column_with_note():
+    fmt = _make_formatter()
+    doc = _make_record(note="Important note about this document")
+    col = fmt._build_content_column(doc, "test")
+    assert "Important note" in col
+
+
+def test_content_column_with_links():
+    fmt = _make_formatter()
+    doc = _make_record(links=DocumentLinks(html="https://example.com/doc", image=["https://example.com/img"]))
+    col = fmt._build_content_column(doc, "test")
+    assert "https://example.com/doc" in col
+    assert "https://example.com/img" in col
+
+
+def test_content_column_snippets_capped_at_three():
+    fmt = _make_formatter()
+    doc = _make_record(num_snippets=5, num_total=5)
+    col = fmt._build_content_column(doc, "test")
+    assert "2 more pages with hits" in col
+
+
+def test_content_column_keyword_highlighted():
+    fmt = _make_formatter()
+    doc = _make_record(keyword="häxa")
+    col = fmt._build_content_column(doc, "häxa")
+    assert "[bold yellow underline]" in col
+
+
+# ── format_search_results ───────────────────────────────────────────────
+
+
+def test_format_search_results_returns_table():
+    result = _make_search_result()
+    table = _make_formatter().format_search_results(result)
+    assert isinstance(table, Table)
+
+
+def test_format_search_results_empty():
+    result = _make_search_result(records=[], total_hits=0)
+    msg = _make_formatter().format_search_results(result)
+    assert isinstance(msg, str)
+    assert "trolldom" in msg
+
+
+def test_format_search_results_max_display():
+    records = [_make_record(record_id=f"SE/RA/{i}", ref_code=f"SE/RA/{i}") for i in range(5)]
+    result = _make_search_result(records=records, total_hits=5)
+    table = _make_formatter().format_search_results(result, max_display=3)
+    assert isinstance(table, Table)
+    assert table.row_count == 3
+
+
+# ── format_search_summary_stats ─────────────────────────────────────────
+
+
+def test_summary_stats_basic():
+    lines = _make_formatter().format_search_summary_stats(
+        snippet_count=10, records_count=5, total_hits=5, offset=0
+    )
+    assert any("10" in line for line in lines)
+    assert any("5" in line for line in lines)
+
+
+def test_summary_stats_with_pagination():
+    lines = _make_formatter().format_search_summary_stats(
+        snippet_count=20, records_count=10, total_hits=100, offset=50
+    )
+    assert any("100" in line for line in lines)
+    assert any("50" in line for line in lines)
+
+
+def test_summary_stats_no_extra_line_when_all_shown():
+    lines = _make_formatter().format_search_summary_stats(
+        snippet_count=3, records_count=3, total_hits=3, offset=0
+    )
+    assert len(lines) == 1
+
+
+def test_summary_stats_plus_when_at_max():
+    lines = _make_formatter().format_search_summary_stats(
+        snippet_count=100, records_count=50, total_hits=200, offset=0, max_requested=50
+    )
+    assert any("50+" in line for line in lines)
+
+
+def test_summary_stats_no_plus_when_below_max():
+    lines = _make_formatter().format_search_summary_stats(
+        snippet_count=10, records_count=5, total_hits=5, offset=0, max_requested=50
+    )
+    assert not any("+" in line for line in lines)
+
+
+# ── format_browse_example ────────────────────────────────────────────────
+
+
+def test_browse_example_with_snippets():
+    result = _make_search_result()
+    lines = _make_formatter().format_browse_example(result.items, "trolldom")
+    assert len(lines) == 2
+    assert "ra browse" in lines[1]
+    assert "trolldom" in lines[1]
+
+
+def test_browse_example_empty():
+    lines = _make_formatter().format_browse_example([], "test")
+    assert lines == []
+
+
+def test_browse_example_no_snippets():
+    doc = SearchRecord(
+        id="SE/RA/1",
+        objectType="Record",
+        metadata=Metadata(referenceCode="SE/RA/1"),
+    )
+    lines = _make_formatter().format_browse_example([doc], "test")
+    assert lines == []
+
+
+# ── format_remaining_documents ───────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "total,displayed,expect_message",
+    [
+        pytest.param(30, 20, True, id="more-remaining"),
+        pytest.param(10, 20, False, id="all-shown"),
+        pytest.param(5, 5, False, id="exact-match"),
+    ],
+)
+def test_format_remaining_documents(total, displayed, expect_message):
+    msg = _make_formatter().format_remaining_documents(total, displayed)
+    if expect_message:
+        assert "10 more" in msg
+    else:
+        assert msg == ""
+
+
+# ── format_no_results_message ────────────────────────────────────────────
+
+
+def test_no_results_at_offset_zero():
+    result = _make_search_result(records=[], total_hits=0, offset=0)
+    msg = _make_formatter().format_no_results_message(result)
+    assert "No results found" in msg
+
+
+def test_no_results_at_positive_offset():
+    result = _make_search_result(records=[], total_hits=50, offset=50)
+    msg = _make_formatter().format_no_results_message(result)
+    assert "No more results" in msg
+    assert "50" in msg


### PR DESCRIPTION
Adds test suites for browse-cli and search-cli packages, which previously had no test coverage.

## What's included

### browse-cli (50 tests)
- **test_browse_cmd.py** — CLI invocation tests covering success path, --pages/--page options, --search-term, --log, --show-links, error handling, and no-args help
- **test_browse_formatter.py** — RichConsoleFormatter tests for text/table/panel formatting, keyword highlighting, page context panels, browse results, and non-digitised material

### search-cli (54 tests)
- **test_search_cmd.py** — CLI invocation tests covering success path, --limit, --max-display, --text mode, --include-all-materials, error handling, and help
- **test_search_formatter.py** — RichConsoleFormatter tests for institution/content columns, search results, summary stats, and keyword highlighting

## Details
- 104 tests, all passing
- Follows testing patterns from CLAUDE.md
- No changes to production code