### PR TITLE
test: add test suite for label-mcp package

### DIFF
--- a/packages/label-mcp/tests/test_converter.py
+++ b/packages/label-mcp/tests/test_converter.py
@@ -1,0 +1,492 @@
+"""Tests for ra_mcp_label_mcp.converter."""
+
+import json
+
+import pytest
+
+from ra_mcp_label_mcp.converter import (
+    _int,
+    _parse_points,
+    _polygon_from_baseline,
+    convert_alto_to_tasks,
+    parse_alto,
+    tasks_to_json,
+    to_label_studio_task,
+)
+
+
+# ---------------------------------------------------------------------------
+# Minimal ALTO XML fixtures
+# ---------------------------------------------------------------------------
+
+ALTO_NS = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<alto xmlns="http://www.loc.gov/standards/alto/ns-v4#">
+  <Description><sourceImageInformation><fileName>page001.jpg</fileName></sourceImageInformation></Description>
+  <Layout>
+    <Page WIDTH="1000" HEIGHT="2000">
+      <PrintSpace>
+        <TextBlock>
+          <TextLine ID="line1" HPOS="10" VPOS="20" WIDTH="200" HEIGHT="40">
+            <Shape><Polygon POINTS="10,20 210,20 210,60 10,60"/></Shape>
+            <String CONTENT="Hello"/>
+            <String CONTENT="World"/>
+          </TextLine>
+        </TextBlock>
+      </PrintSpace>
+    </Page>
+  </Layout>
+</alto>
+"""
+
+ALTO_NO_NS = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<alto>
+  <Description><sourceImageInformation><fileName>nonamespace.jpg</fileName></sourceImageInformation></Description>
+  <Layout>
+    <Page WIDTH="500" HEIGHT="800">
+      <PrintSpace>
+        <TextBlock>
+          <TextLine ID="tl_1" HPOS="5" VPOS="10" WIDTH="100" HEIGHT="20">
+            <Shape><Polygon POINTS="5,10 105,10 105,30 5,30"/></Shape>
+            <String CONTENT="NoNS"/>
+          </TextLine>
+        </TextBlock>
+      </PrintSpace>
+    </Page>
+  </Layout>
+</alto>
+"""
+
+ALTO_BASELINE_ONLY = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<alto xmlns="http://www.loc.gov/standards/alto/ns-v4#">
+  <Description><sourceImageInformation><fileName>baseline.jpg</fileName></sourceImageInformation></Description>
+  <Layout>
+    <Page WIDTH="600" HEIGHT="400">
+      <PrintSpace>
+        <TextBlock>
+          <TextLine ID="bl1" BASELINE="100,200 300,200">
+            <String CONTENT="Baseline"/>
+            <String CONTENT="Only"/>
+          </TextLine>
+        </TextBlock>
+      </PrintSpace>
+    </Page>
+  </Layout>
+</alto>
+"""
+
+ALTO_BBOX_FALLBACK = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<alto xmlns="http://www.loc.gov/standards/alto/ns-v4#">
+  <Description><sourceImageInformation><fileName>bbox.jpg</fileName></sourceImageInformation></Description>
+  <Layout>
+    <Page WIDTH="800" HEIGHT="600">
+      <PrintSpace>
+        <TextBlock>
+          <TextLine ID="bx1" HPOS="50" VPOS="100" WIDTH="200" HEIGHT="30">
+            <String CONTENT="BBox"/>
+          </TextLine>
+        </TextBlock>
+      </PrintSpace>
+    </Page>
+  </Layout>
+</alto>
+"""
+
+ALTO_NO_TEXTLINES = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<alto xmlns="http://www.loc.gov/standards/alto/ns-v4#">
+  <Description><sourceImageInformation><fileName>empty.jpg</fileName></sourceImageInformation></Description>
+  <Layout>
+    <Page WIDTH="100" HEIGHT="100">
+      <PrintSpace/>
+    </Page>
+  </Layout>
+</alto>
+"""
+
+ALTO_MISSING_FILENAME = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<alto xmlns="http://www.loc.gov/standards/alto/ns-v4#">
+  <Description><sourceImageInformation/></Description>
+  <Layout>
+    <Page WIDTH="100" HEIGHT="100">
+      <PrintSpace/>
+    </Page>
+  </Layout>
+</alto>
+"""
+
+ALTO_NO_PAGE = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<alto xmlns="http://www.loc.gov/standards/alto/ns-v4#">
+  <Layout/>
+</alto>
+"""
+
+
+# ---------------------------------------------------------------------------
+# _int
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "value,default,expected",
+    [
+        pytest.param("42", 0, 42, id="normal-int"),
+        pytest.param("0", 0, 0, id="zero-string"),
+        pytest.param(None, 0, 0, id="none-default"),
+        pytest.param("", 0, 0, id="empty-string-default"),
+        pytest.param("abc", 0, 0, id="non-numeric-default"),
+        pytest.param(None, 99, 99, id="none-custom-default"),
+        pytest.param("abc", 5, 5, id="non-numeric-custom-default"),
+        pytest.param("-10", 0, -10, id="negative-int"),
+    ],
+)
+def test_int(value, default, expected):
+    assert _int(value, default) == expected
+
+
+# ---------------------------------------------------------------------------
+# _parse_points
+# ---------------------------------------------------------------------------
+
+
+def test_parse_points_standard():
+    assert _parse_points("10,20 30,40 50,60") == [(10, 20), (30, 40), (50, 60)]
+
+
+def test_parse_points_single():
+    assert _parse_points("100,200") == [(100, 200)]
+
+
+def test_parse_points_leading_trailing_whitespace():
+    assert _parse_points("  10,20  30,40  ") == [(10, 20), (30, 40)]
+
+
+# ---------------------------------------------------------------------------
+# _polygon_from_baseline
+# ---------------------------------------------------------------------------
+
+
+def test_polygon_from_baseline_two_points():
+    polygon = _polygon_from_baseline("100,200 300,200")
+    assert polygon == "100,160 300,160 300,215 100,215"
+
+
+def test_polygon_from_baseline_custom_offsets():
+    polygon = _polygon_from_baseline("100,200 300,200", ascent=10, descent=5)
+    assert polygon == "100,190 300,190 300,205 100,205"
+
+
+def test_polygon_from_baseline_clamps_y_to_zero():
+    polygon = _polygon_from_baseline("100,20 300,20", ascent=40, descent=15)
+    assert "100,0" in polygon
+
+
+def test_polygon_from_baseline_single_point_returns_empty():
+    assert _polygon_from_baseline("100,200") == ""
+
+
+def test_polygon_from_baseline_empty_string():
+    assert _polygon_from_baseline("") == ""
+
+
+def test_polygon_from_baseline_invalid_data():
+    assert _polygon_from_baseline("not,valid nope") == ""
+
+
+def test_polygon_from_baseline_three_points():
+    polygon = _polygon_from_baseline("100,200 200,200 300,200")
+    parts = polygon.split()
+    assert len(parts) == 6
+
+
+# ---------------------------------------------------------------------------
+# parse_alto — namespaced
+# ---------------------------------------------------------------------------
+
+
+def test_parse_alto_namespaced():
+    result = parse_alto(ALTO_NS)
+    assert result["filename"] == "page001.jpg"
+    assert result["page_width"] == 1000
+    assert result["page_height"] == 2000
+    assert len(result["textlines"]) == 1
+
+    tl = result["textlines"][0]
+    assert tl["text"] == "Hello World"
+    assert tl["id"] == "line1"
+    assert tl["points"] == [(10, 20), (210, 20), (210, 60), (10, 60)]
+
+
+# ---------------------------------------------------------------------------
+# parse_alto — no namespace
+# ---------------------------------------------------------------------------
+
+
+def test_parse_alto_no_namespace():
+    result = parse_alto(ALTO_NO_NS)
+    assert result["filename"] == "nonamespace.jpg"
+    assert result["page_width"] == 500
+    assert result["page_height"] == 800
+    assert len(result["textlines"]) == 1
+    assert result["textlines"][0]["text"] == "NoNS"
+
+
+# ---------------------------------------------------------------------------
+# parse_alto — polygon fallback chain
+# ---------------------------------------------------------------------------
+
+
+def test_parse_alto_baseline_fallback():
+    result = parse_alto(ALTO_BASELINE_ONLY)
+    assert result["filename"] == "baseline.jpg"
+    assert len(result["textlines"]) == 1
+    tl = result["textlines"][0]
+    assert tl["text"] == "Baseline Only"
+    assert len(tl["points"]) > 2
+
+
+def test_parse_alto_bbox_fallback():
+    result = parse_alto(ALTO_BBOX_FALLBACK)
+    assert len(result["textlines"]) == 1
+    tl = result["textlines"][0]
+    assert tl["points"] == [(50, 100), (250, 100), (250, 130), (50, 130)]
+    assert tl["text"] == "BBox"
+
+
+# ---------------------------------------------------------------------------
+# parse_alto — edge cases
+# ---------------------------------------------------------------------------
+
+
+def test_parse_alto_no_textlines():
+    result = parse_alto(ALTO_NO_TEXTLINES)
+    assert result["textlines"] == []
+    assert result["filename"] == "empty.jpg"
+
+
+def test_parse_alto_missing_filename():
+    result = parse_alto(ALTO_MISSING_FILENAME)
+    assert result["filename"] == "unknown"
+
+
+def test_parse_alto_no_page_raises():
+    with pytest.raises(ValueError, match="No <Page> element"):
+        parse_alto(ALTO_NO_PAGE)
+
+
+# ---------------------------------------------------------------------------
+# to_label_studio_task
+# ---------------------------------------------------------------------------
+
+
+_DEFAULT_TEXTLINES = [
+    {
+        "points": [(100, 200), (300, 200), (300, 250), (100, 250)],
+        "text": "Sample text",
+        "id": "tl1",
+    }
+]
+
+
+def _make_parsed(textlines=None, width=1000, height=2000, filename="test.jpg"):
+    return {
+        "filename": filename,
+        "page_width": width,
+        "page_height": height,
+        "textlines": _DEFAULT_TEXTLINES if textlines is None else textlines,
+    }
+
+
+def test_to_label_studio_task_with_image_url():
+    parsed = _make_parsed()
+    task = to_label_studio_task(parsed, image_url="https://example.com/page.jpg")
+
+    assert task["data"]["ocr"] == "https://example.com/page.jpg"
+    assert "predictions" in task
+    assert len(task["predictions"]) == 1
+    results = task["predictions"][0]["result"]
+    assert len(results) == 2
+    assert results[0]["type"] == "vectorlabels"
+    assert results[1]["type"] == "textarea"
+
+
+def test_to_label_studio_task_default_image_url():
+    parsed = _make_parsed()
+    task = to_label_studio_task(parsed)
+    assert task["data"]["ocr"] == "/data/local-files/?d=test.jpg"
+
+
+def test_to_label_studio_task_vectorlabels_structure():
+    parsed = _make_parsed()
+    task = to_label_studio_task(parsed, image_url="https://img.test/1.jpg")
+    vl = task["predictions"][0]["result"][0]
+
+    assert vl["from_name"] == "label"
+    assert vl["to_name"] == "image"
+    assert vl["original_width"] == 1000
+    assert vl["original_height"] == 2000
+    assert vl["image_rotation"] == 0
+    assert vl["value"]["closed"] is True
+    assert vl["value"]["vectorlabels"] == ["Textlines"]
+
+    vertices = vl["value"]["vertices"]
+    assert len(vertices) == 4
+    assert vertices[0]["x"] == pytest.approx(10.0)
+    assert vertices[0]["y"] == pytest.approx(10.0)
+    assert vertices[0]["isBezier"] is False
+    assert vertices[0]["prevPointId"] is None
+    assert vertices[1]["prevPointId"] == vertices[0]["id"]
+
+
+def test_to_label_studio_task_textarea_structure():
+    parsed = _make_parsed()
+    task = to_label_studio_task(parsed, image_url="https://img.test/1.jpg")
+    ta = task["predictions"][0]["result"][1]
+
+    assert ta["type"] == "textarea"
+    assert ta["from_name"] == "transcription"
+    assert ta["value"]["text"] == ["Sample text"]
+
+
+def test_to_label_studio_task_with_feedback():
+    parsed = _make_parsed()
+    task = to_label_studio_task(parsed, image_url="https://img.test/1.jpg", feedback=["Transcription"])
+    results = task["predictions"][0]["result"]
+    assert len(results) == 3
+    fb = results[2]
+    assert fb["type"] == "choices"
+    assert fb["from_name"] == "feedback"
+    assert fb["value"]["choices"] == ["Transcription"]
+
+
+def test_to_label_studio_task_with_multiple_feedback():
+    parsed = _make_parsed()
+    task = to_label_studio_task(
+        parsed,
+        image_url="https://img.test/1.jpg",
+        feedback=["Transcription", "Segmentation"],
+    )
+    fb = task["predictions"][0]["result"][2]
+    assert fb["value"]["choices"] == ["Transcription", "Segmentation"]
+
+
+def test_to_label_studio_task_no_feedback_means_two_results():
+    parsed = _make_parsed()
+    task = to_label_studio_task(parsed, image_url="https://img.test/1.jpg", feedback=None)
+    assert len(task["predictions"][0]["result"]) == 2
+
+
+def test_to_label_studio_task_empty_textlines():
+    parsed = _make_parsed(textlines=[])
+    task = to_label_studio_task(parsed, image_url="https://img.test/1.jpg")
+    assert task["predictions"][0]["result"] == []
+
+
+def test_to_label_studio_task_region_ids_shared():
+    """VectorLabels and textarea for same textline share the same region ID."""
+    parsed = _make_parsed()
+    task = to_label_studio_task(parsed, image_url="https://img.test/1.jpg")
+    results = task["predictions"][0]["result"]
+    assert results[0]["id"] == results[1]["id"]
+
+
+def test_to_label_studio_task_multiple_textlines():
+    parsed = _make_parsed(
+        textlines=[
+            {"points": [(0, 0), (100, 0), (100, 50), (0, 50)], "text": "Line 1", "id": "l1"},
+            {"points": [(0, 60), (100, 60), (100, 110), (0, 110)], "text": "Line 2", "id": "l2"},
+        ]
+    )
+    task = to_label_studio_task(parsed, image_url="https://img.test/1.jpg")
+    results = task["predictions"][0]["result"]
+    assert len(results) == 4
+    assert results[0]["id"] != results[2]["id"]
+
+
+def test_to_label_studio_task_percentage_coordinates():
+    """Coordinates are converted from absolute pixels to percentages of page dimensions."""
+    parsed = _make_parsed(
+        textlines=[
+            {"points": [(500, 1000)], "text": "center", "id": "c"},
+        ],
+        width=1000,
+        height=2000,
+    )
+    task = to_label_studio_task(parsed, image_url="https://img.test/1.jpg")
+    vertex = task["predictions"][0]["result"][0]["value"]["vertices"][0]
+    assert vertex["x"] == pytest.approx(50.0)
+    assert vertex["y"] == pytest.approx(50.0)
+
+
+# ---------------------------------------------------------------------------
+# convert_alto_to_tasks
+# ---------------------------------------------------------------------------
+
+
+def test_convert_alto_to_tasks_single():
+    tasks = convert_alto_to_tasks([ALTO_NS], image_urls=["https://img.test/1.jpg"])
+    assert len(tasks) == 1
+    assert tasks[0]["data"]["ocr"] == "https://img.test/1.jpg"
+    assert len(tasks[0]["predictions"][0]["result"]) == 2
+
+
+def test_convert_alto_to_tasks_multiple():
+    tasks = convert_alto_to_tasks(
+        [ALTO_NS, ALTO_NO_NS],
+        image_urls=["https://img.test/1.jpg", "https://img.test/2.jpg"],
+    )
+    assert len(tasks) == 2
+    assert tasks[0]["data"]["ocr"] == "https://img.test/1.jpg"
+    assert tasks[1]["data"]["ocr"] == "https://img.test/2.jpg"
+
+
+def test_convert_alto_to_tasks_no_image_urls():
+    tasks = convert_alto_to_tasks([ALTO_NS])
+    assert tasks[0]["data"]["ocr"] == "/data/local-files/?d=page001.jpg"
+
+
+def test_convert_alto_to_tasks_with_feedback():
+    tasks = convert_alto_to_tasks(
+        [ALTO_NS],
+        image_urls=["https://img.test/1.jpg"],
+        feedback_list=[["Transcription"]],
+    )
+    results = tasks[0]["predictions"][0]["result"]
+    assert any(r["type"] == "choices" for r in results)
+
+
+def test_convert_alto_to_tasks_partial_image_urls():
+    tasks = convert_alto_to_tasks(
+        [ALTO_NS, ALTO_NO_NS],
+        image_urls=["https://img.test/1.jpg"],
+    )
+    assert tasks[0]["data"]["ocr"] == "https://img.test/1.jpg"
+    assert tasks[1]["data"]["ocr"] == "/data/local-files/?d=nonamespace.jpg"
+
+
+# ---------------------------------------------------------------------------
+# tasks_to_json
+# ---------------------------------------------------------------------------
+
+
+def test_tasks_to_json_valid():
+    tasks = [{"data": {"ocr": "https://example.com/img.jpg"}}]
+    result = tasks_to_json(tasks)
+    parsed = json.loads(result)
+    assert parsed == tasks
+
+
+def test_tasks_to_json_ensure_ascii_false():
+    tasks = [{"data": {"ocr": "https://example.com/åäö.jpg"}}]
+    result = tasks_to_json(tasks)
+    assert "åäö" in result
+
+
+def test_tasks_to_json_empty_list():
+    result = tasks_to_json([])
+    assert json.loads(result) == []

--- a/packages/label-mcp/tests/test_label_tool.py
+++ b/packages/label-mcp/tests/test_label_tool.py
@@ -1,0 +1,288 @@
+"""Tests for ra_mcp_label_mcp.label_tool."""
+
+import json
+import os
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastmcp import Client
+from fastmcp.exceptions import ToolError
+
+from ra_mcp_label_mcp.label_tool import _build_image_only_tasks
+from ra_mcp_label_mcp.tools import label_mcp
+
+
+# ---------------------------------------------------------------------------
+# _build_image_only_tasks
+# ---------------------------------------------------------------------------
+
+
+def test_build_image_only_tasks_single():
+    tasks = _build_image_only_tasks(["https://img.test/1.jpg"])
+    assert tasks == [{"data": {"ocr": "https://img.test/1.jpg"}}]
+
+
+def test_build_image_only_tasks_multiple():
+    tasks = _build_image_only_tasks(["https://img.test/1.jpg", "https://img.test/2.jpg"])
+    assert len(tasks) == 2
+    assert tasks[1]["data"]["ocr"] == "https://img.test/2.jpg"
+
+
+def test_build_image_only_tasks_empty():
+    assert _build_image_only_tasks([]) == []
+
+
+# ---------------------------------------------------------------------------
+# MCP tool — dry_run mode (no Label Studio needed)
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_dry_run_image_only():
+    async with Client(label_mcp) as client:
+        result = await client.call_tool(
+            "import_to_label_studio",
+            {
+                "image_urls": ["https://img.test/1.jpg", "https://img.test/2.jpg"],
+                "dry_run": True,
+            },
+        )
+    text = result.content[0].text
+    tasks = json.loads(text)
+    assert len(tasks) == 2
+    assert tasks[0]["data"]["ocr"] == "https://img.test/1.jpg"
+    assert "predictions" not in tasks[0]
+
+
+async def test_tool_dry_run_with_alto():
+    alto_xml = """\
+<?xml version="1.0" encoding="UTF-8"?>
+<alto xmlns="http://www.loc.gov/standards/alto/ns-v4#">
+  <Description><sourceImageInformation><fileName>p.jpg</fileName></sourceImageInformation></Description>
+  <Layout>
+    <Page WIDTH="500" HEIGHT="500">
+      <PrintSpace>
+        <TextBlock>
+          <TextLine ID="l1" HPOS="0" VPOS="0" WIDTH="100" HEIGHT="20">
+            <Shape><Polygon POINTS="0,0 100,0 100,20 0,20"/></Shape>
+            <String CONTENT="Test"/>
+          </TextLine>
+        </TextBlock>
+      </PrintSpace>
+    </Page>
+  </Layout>
+</alto>
+"""
+    import httpx
+
+    mock_response = httpx.Response(200, text=alto_xml, request=httpx.Request("GET", "https://alto.test/1.xml"))
+
+    with patch("ra_mcp_label_mcp.label_tool.httpx.AsyncClient") as mock_cls:
+        mock_client = AsyncMock()
+        mock_client.get.return_value = mock_response
+        mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+        mock_client.__aexit__ = AsyncMock(return_value=False)
+        mock_cls.return_value = mock_client
+
+        async with Client(label_mcp) as client:
+            result = await client.call_tool(
+                "import_to_label_studio",
+                {
+                    "image_urls": ["https://img.test/1.jpg"],
+                    "alto_urls": ["https://alto.test/1.xml"],
+                    "dry_run": True,
+                },
+            )
+
+    text = result.content[0].text
+    tasks = json.loads(text)
+    assert len(tasks) == 1
+    assert "predictions" in tasks[0]
+    assert tasks[0]["data"]["ocr"] == "https://img.test/1.jpg"
+
+
+# ---------------------------------------------------------------------------
+# MCP tool — validation errors (ToolError raised by fastmcp Client)
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_mismatched_alto_image_urls():
+    with pytest.raises(ToolError, match="same length"):
+        async with Client(label_mcp) as client:
+            await client.call_tool(
+                "import_to_label_studio",
+                {
+                    "image_urls": ["https://img.test/1.jpg"],
+                    "alto_urls": ["https://alto.test/1.xml", "https://alto.test/2.xml"],
+                    "dry_run": True,
+                },
+            )
+
+
+async def test_tool_feedback_without_alto_raises():
+    with pytest.raises(ToolError, match="requires alto_urls"):
+        async with Client(label_mcp) as client:
+            await client.call_tool(
+                "import_to_label_studio",
+                {
+                    "image_urls": ["https://img.test/1.jpg"],
+                    "feedback": [["Transcription"]],
+                    "dry_run": True,
+                },
+            )
+
+
+async def test_tool_mismatched_feedback_length():
+    with pytest.raises(ToolError, match="same length"):
+        async with Client(label_mcp) as client:
+            await client.call_tool(
+                "import_to_label_studio",
+                {
+                    "image_urls": ["https://img.test/1.jpg"],
+                    "alto_urls": ["https://alto.test/1.xml"],
+                    "feedback": [["Transcription"], ["Segmentation"]],
+                    "dry_run": True,
+                },
+            )
+
+
+# ---------------------------------------------------------------------------
+# MCP tool — missing credentials (non-dry-run)
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_missing_ls_url():
+    env = {k: v for k, v in os.environ.items() if k not in ("LS_URL", "LS_TOKEN", "LS_PROJECT_ID")}
+    with patch.dict("os.environ", env, clear=True):
+        with pytest.raises(ToolError, match="(?i)url required"):
+            async with Client(label_mcp) as client:
+                await client.call_tool(
+                    "import_to_label_studio",
+                    {"image_urls": ["https://img.test/1.jpg"]},
+                )
+
+
+async def test_tool_missing_token():
+    env = {k: v for k, v in os.environ.items() if k not in ("LS_TOKEN", "LS_PROJECT_ID")}
+    env["LS_URL"] = "https://ls.test"
+    with patch.dict("os.environ", env, clear=True):
+        with pytest.raises(ToolError, match="(?i)token required"):
+            async with Client(label_mcp) as client:
+                await client.call_tool(
+                    "import_to_label_studio",
+                    {"image_urls": ["https://img.test/1.jpg"]},
+                )
+
+
+async def test_tool_missing_project_id():
+    env = {k: v for k, v in os.environ.items() if k not in ("LS_PROJECT_ID",)}
+    env["LS_URL"] = "https://ls.test"
+    env["LS_TOKEN"] = "abc"
+    with patch.dict("os.environ", env, clear=True):
+        with pytest.raises(ToolError, match="(?i)project id required"):
+            async with Client(label_mcp) as client:
+                await client.call_tool(
+                    "import_to_label_studio",
+                    {"image_urls": ["https://img.test/1.jpg"]},
+                )
+
+
+# ---------------------------------------------------------------------------
+# MCP tool — successful import (mocked Label Studio SDK)
+# ---------------------------------------------------------------------------
+
+
+async def test_tool_import_success():
+    with (
+        patch.dict(
+            "os.environ",
+            {"LS_URL": "https://ls.test", "LS_TOKEN": "tok", "LS_PROJECT_ID": "99"},
+        ),
+        patch(
+            "ra_mcp_label_mcp.label_tool.import_tasks",
+            return_value={"task_count": 2, "task_ids": [1, 2]},
+        ),
+    ):
+        async with Client(label_mcp) as client:
+            result = await client.call_tool(
+                "import_to_label_studio",
+                {"image_urls": ["https://img.test/1.jpg", "https://img.test/2.jpg"]},
+            )
+    text = result.content[0].text
+    assert "Successfully imported 2" in text
+    assert "project 99" in text
+    assert "/projects/99/data?task=1" in text
+    assert "/projects/99/data?task=2" in text
+
+
+async def test_tool_import_with_assignment():
+    with (
+        patch.dict(
+            "os.environ",
+            {"LS_URL": "https://ls.test", "LS_TOKEN": "tok", "LS_PROJECT_ID": "5"},
+        ),
+        patch(
+            "ra_mcp_label_mcp.label_tool.import_tasks",
+            return_value={"task_count": 1, "task_ids": [42]},
+        ),
+        patch(
+            "ra_mcp_label_mcp.label_tool.assign_tasks",
+            return_value="Alice Smith",
+        ),
+    ):
+        async with Client(label_mcp) as client:
+            result = await client.call_tool(
+                "import_to_label_studio",
+                {
+                    "image_urls": ["https://img.test/1.jpg"],
+                    "assign_to": "alice@example.com",
+                },
+            )
+    text = result.content[0].text
+    assert "Alice Smith" in text
+
+
+async def test_tool_import_assignment_failure_non_fatal():
+    with (
+        patch.dict(
+            "os.environ",
+            {"LS_URL": "https://ls.test", "LS_TOKEN": "tok", "LS_PROJECT_ID": "5"},
+        ),
+        patch(
+            "ra_mcp_label_mcp.label_tool.import_tasks",
+            return_value={"task_count": 1, "task_ids": [42]},
+        ),
+        patch(
+            "ra_mcp_label_mcp.label_tool.assign_tasks",
+            side_effect=RuntimeError("user not found"),
+        ),
+    ):
+        async with Client(label_mcp) as client:
+            result = await client.call_tool(
+                "import_to_label_studio",
+                {
+                    "image_urls": ["https://img.test/1.jpg"],
+                    "assign_to": "nobody@example.com",
+                },
+            )
+    text = result.content[0].text
+    assert "Successfully imported" in text
+    assert "Assignment failed" in text
+
+
+async def test_tool_import_api_error():
+    with (
+        patch.dict(
+            "os.environ",
+            {"LS_URL": "https://ls.test", "LS_TOKEN": "tok", "LS_PROJECT_ID": "5"},
+        ),
+        patch(
+            "ra_mcp_label_mcp.label_tool.import_tasks",
+            side_effect=RuntimeError("API error 500"),
+        ),
+    ):
+        with pytest.raises(ToolError, match="API error 500"):
+            async with Client(label_mcp) as client:
+                await client.call_tool(
+                    "import_to_label_studio",
+                    {"image_urls": ["https://img.test/1.jpg"]},
+                )

--- a/packages/label-mcp/tests/test_ls_client.py
+++ b/packages/label-mcp/tests/test_ls_client.py
@@ -1,0 +1,156 @@
+"""Tests for ra_mcp_label_mcp.ls_client."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from ra_mcp_label_mcp.ls_client import _get_client, assign_tasks, import_tasks
+
+
+# ---------------------------------------------------------------------------
+# _get_client
+# ---------------------------------------------------------------------------
+
+
+def test_get_client_strips_trailing_slash():
+    with patch("ra_mcp_label_mcp.ls_client.LabelStudio") as mock_cls:
+        _get_client("https://ls.example.com/", "tok123")
+        mock_cls.assert_called_once_with(base_url="https://ls.example.com", api_key="tok123")
+
+
+def test_get_client_strips_token_whitespace():
+    with patch("ra_mcp_label_mcp.ls_client.LabelStudio") as mock_cls:
+        _get_client("https://ls.example.com", "  tok123  ")
+        mock_cls.assert_called_once_with(base_url="https://ls.example.com", api_key="tok123")
+
+
+# ---------------------------------------------------------------------------
+# import_tasks
+# ---------------------------------------------------------------------------
+
+
+def test_import_tasks_success():
+    mock_result = SimpleNamespace(task_count=2, task_ids=[10, 11])
+    mock_client = MagicMock()
+    mock_client.projects.import_tasks.return_value = mock_result
+
+    with patch("ra_mcp_label_mcp.ls_client._get_client", return_value=mock_client):
+        result = import_tasks(
+            [{"data": {"ocr": "a"}}, {"data": {"ocr": "b"}}],
+            "https://ls.example.com",
+            "token",
+            42,
+        )
+
+    assert result == {"task_count": 2, "task_ids": [10, 11]}
+    mock_client.projects.import_tasks.assert_called_once_with(
+        id=42,
+        request=[{"data": {"ocr": "a"}}, {"data": {"ocr": "b"}}],
+        return_task_ids=True,
+    )
+
+
+def test_import_tasks_fallback_count():
+    mock_result = SimpleNamespace()
+    mock_client = MagicMock()
+    mock_client.projects.import_tasks.return_value = mock_result
+
+    with patch("ra_mcp_label_mcp.ls_client._get_client", return_value=mock_client):
+        result = import_tasks([{"data": {"ocr": "a"}}], "https://ls.example.com", "token", 1)
+
+    assert result["task_count"] == 1
+    assert result["task_ids"] == []
+
+
+def test_import_tasks_api_error():
+    from label_studio_sdk.core.api_error import ApiError
+
+    mock_client = MagicMock()
+    mock_client.projects.import_tasks.side_effect = ApiError(status_code=403, body="Forbidden")
+
+    with patch("ra_mcp_label_mcp.ls_client._get_client", return_value=mock_client):
+        with pytest.raises(RuntimeError, match="Label Studio API error 403"):
+            import_tasks([{"data": {"ocr": "a"}}], "https://ls.example.com", "token", 1)
+
+
+def test_import_tasks_generic_error():
+    mock_client = MagicMock()
+    mock_client.projects.import_tasks.side_effect = ConnectionError("network down")
+
+    with patch("ra_mcp_label_mcp.ls_client._get_client", return_value=mock_client):
+        with pytest.raises(RuntimeError, match="Label Studio API request failed"):
+            import_tasks([{"data": {"ocr": "a"}}], "https://ls.example.com", "token", 1)
+
+
+# ---------------------------------------------------------------------------
+# assign_tasks
+# ---------------------------------------------------------------------------
+
+
+def _make_user(user_id, email, first_name="", last_name=""):
+    return SimpleNamespace(id=user_id, email=email, first_name=first_name, last_name=last_name)
+
+
+def test_assign_tasks_success():
+    users = [
+        _make_user(1, "alice@example.com", "Alice", "Smith"),
+        _make_user(2, "bob@example.com", "Bob", "Jones"),
+    ]
+    mock_client = MagicMock()
+    mock_client.users.list.return_value = iter(users)
+
+    with patch("ra_mcp_label_mcp.ls_client._get_client", return_value=mock_client):
+        name = assign_tasks([10, 11], "alice@example.com", "https://ls.example.com", "token", 42)
+
+    assert name == "Alice Smith"
+    mock_client.projects.assignments.bulk_assign.assert_called_once_with(
+        id=42,
+        type="AN",
+        users=[1],
+        selected_items={"all": False, "included": [10, 11]},
+    )
+
+
+def test_assign_tasks_case_insensitive_email():
+    users = [_make_user(1, "Alice@Example.COM", "Alice", "")]
+    mock_client = MagicMock()
+    mock_client.users.list.return_value = iter(users)
+
+    with patch("ra_mcp_label_mcp.ls_client._get_client", return_value=mock_client):
+        name = assign_tasks([10], "alice@example.com", "https://ls.example.com", "token", 1)
+
+    assert name == "Alice"
+
+
+def test_assign_tasks_falls_back_to_email_for_name():
+    users = [_make_user(1, "anon@example.com", "", "")]
+    mock_client = MagicMock()
+    mock_client.users.list.return_value = iter(users)
+
+    with patch("ra_mcp_label_mcp.ls_client._get_client", return_value=mock_client):
+        name = assign_tasks([10], "anon@example.com", "https://ls.example.com", "token", 1)
+
+    assert name == "anon@example.com"
+
+
+def test_assign_tasks_user_not_found():
+    mock_client = MagicMock()
+    mock_client.users.list.return_value = iter([])
+
+    with patch("ra_mcp_label_mcp.ls_client._get_client", return_value=mock_client):
+        with pytest.raises(RuntimeError, match="No Label Studio user found"):
+            assign_tasks([10], "nobody@example.com", "https://ls.example.com", "token", 1)
+
+
+def test_assign_tasks_api_error():
+    from label_studio_sdk.core.api_error import ApiError
+
+    users = [_make_user(1, "alice@example.com", "Alice", "")]
+    mock_client = MagicMock()
+    mock_client.users.list.return_value = iter(users)
+    mock_client.projects.assignments.bulk_assign.side_effect = ApiError(status_code=500, body="fail")
+
+    with patch("ra_mcp_label_mcp.ls_client._get_client", return_value=mock_client):
+        with pytest.raises(RuntimeError, match="Label Studio assignment error 500"):
+            assign_tasks([10], "alice@example.com", "https://ls.example.com", "token", 1)

--- a/packages/label-mcp/tests/test_tools.py
+++ b/packages/label-mcp/tests/test_tools.py
@@ -1,0 +1,12 @@
+"""Tests for ra_mcp_label_mcp.tools (server setup)."""
+
+from ra_mcp_label_mcp.tools import label_mcp
+
+
+def test_label_mcp_has_name():
+    assert label_mcp.name == "ra-label-mcp"
+
+
+def test_label_mcp_has_instructions():
+    assert label_mcp.instructions
+    assert "import_to_label_studio" in label_mcp.instructions


### PR DESCRIPTION
Adds test suite for the label-mcp package, which previously had no test coverage.

## What's included

- **test_converter.py** (44 tests) — All converter functions: _int edge cases, _parse_points, _polygon_from_baseline, parse_alto (namespaced/no-namespace/baseline/bbox fallback), to_label_studio_task, convert_alto_to_tasks, tasks_to_json
- **test_ls_client.py** (11 tests) — Label Studio SDK client: _get_client, import_tasks, assign_tasks
- **test_label_tool.py** (15 tests) — MCP tool via fastmcp.Client: dry-run, validation errors, missing credentials, import success/failure
- **test_tools.py** (2 tests) — Server setup verification

## Details
- 72 tests, all passing
- Follows testing patterns from CLAUDE.md
- No changes to production code