### PR TITLE
test: add test suite for pdf-mcp package

### DIFF
--- a/packages/pdf-mcp/tests/conftest.py
+++ b/packages/pdf-mcp/tests/conftest.py
@@ -1,0 +1,73 @@
+"""Shared fixtures for pdf-mcp tests."""
+
+import pytest
+
+import ra_mcp_pdf_mcp.state as _state_mod
+import ra_mcp_pdf_mcp.cache as _cache_mod
+
+
+@pytest.fixture(autouse=True)
+def _reset_state():
+    """Reset module-level state between tests."""
+    _state_mod.latest_view_id = ""
+    _cache_mod.pdf_cache.clear()
+    _cache_mod.blocks_cache.clear()
+    yield
+    _state_mod.latest_view_id = ""
+    _cache_mod.pdf_cache.clear()
+    _cache_mod.blocks_cache.clear()
+
+
+@pytest.fixture()
+def sample_pages() -> list[dict]:
+    """Structured JSON pages mimicking the DataLab format."""
+    return [
+        {
+            "page": 0,
+            "bbox": [0, 0, 595, 842],
+            "children": [
+                {
+                    "html": "<p>Kungliga Majestäts kansli</p>",
+                    "bbox": [72, 100, 400, 130],
+                    "block_type": "SectionHeader",
+                },
+                {
+                    "html": "<p>Stockholm den 15 mars 1723</p>",
+                    "bbox": [72, 140, 400, 160],
+                    "block_type": "Text",
+                },
+                {
+                    "html": "<p>Trolldomsprocessen i Norrland</p>",
+                    "bbox": [72, 170, 400, 190],
+                    "block_type": "Text",
+                },
+            ],
+        },
+        {
+            "page": 1,
+            "bbox": [0, 0, 595, 842],
+            "children": [
+                {
+                    "html": "<p>Domstolens <b>beslut</b> i målet</p>",
+                    "bbox": [72, 100, 400, 130],
+                    "block_type": "Text",
+                },
+                {
+                    "html": "",
+                    "bbox": [72, 140, 400, 160],
+                    "block_type": "Figure",
+                },
+            ],
+        },
+        {
+            "page": 2,
+            "bbox": [0, 0, 595, 842],
+            "children": [
+                {
+                    "html": "<p>Stockholm Stockholm Stockholm</p>",
+                    "bbox": [72, 100, 400, 130],
+                    "block_type": "Text",
+                },
+            ],
+        },
+    ]

--- a/packages/pdf-mcp/tests/test_cache.py
+++ b/packages/pdf-mcp/tests/test_cache.py
@@ -1,0 +1,189 @@
+"""Tests for ra_mcp_pdf_mcp.cache."""
+
+import pytest
+from unittest.mock import AsyncMock, patch, MagicMock
+
+from ra_mcp_pdf_mcp.cache import (
+    MAX_PDF_SIZE,
+    json_url_for,
+    pdf_cache,
+    read_pdf_range,
+)
+
+
+# ── json_url_for ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "url,expected",
+    [
+        pytest.param(
+            "https://huggingface.co/buckets/Riksarkivet/pdfs/resolve/doc.pdf?download=true",
+            "https://huggingface.co/buckets/Riksarkivet/pdfs/resolve/doc.json?download=true",
+            id="standard-hf-pdf",
+        ),
+        pytest.param(
+            "https://example.com/doc.pdf",
+            None,
+            id="non-huggingface",
+        ),
+        pytest.param(
+            "https://huggingface.co/buckets/Riksarkivet/pdfs/resolve/doc.txt",
+            None,
+            id="huggingface-non-pdf",
+        ),
+        pytest.param(
+            "https://huggingface.co/buckets/file.pdf.extra.pdf",
+            "https://huggingface.co/buckets/file.json.extra.pdf",
+            id="replaces-first-pdf-only",
+        ),
+    ],
+)
+def test_json_url_for(url, expected):
+    assert json_url_for(url) == expected
+
+
+# ── read_pdf_range with cached data ─────────────────────────────────
+
+
+async def test_read_pdf_range_from_cache():
+    url = "https://example.com/cached.pdf"
+    data = b"0123456789" * 100
+    pdf_cache[url] = data
+
+    chunk, total = await read_pdf_range(url, 0, 50)
+    assert chunk == data[:50]
+    assert total == len(data)
+
+
+async def test_read_pdf_range_from_cache_offset():
+    url = "https://example.com/cached.pdf"
+    data = b"ABCDEFGHIJ"
+    pdf_cache[url] = data
+
+    chunk, total = await read_pdf_range(url, 3, 4)
+    assert chunk == b"DEFG"
+    assert total == 10
+
+
+async def test_read_pdf_range_from_cache_beyond_end():
+    url = "https://example.com/cached.pdf"
+    data = b"short"
+    pdf_cache[url] = data
+
+    chunk, total = await read_pdf_range(url, 3, 100)
+    assert chunk == b"rt"
+    assert total == 5
+
+
+# ── read_pdf_range with HTTP Range (206) ─────────────────────────────
+
+
+async def test_read_pdf_range_http_206():
+    url = "https://example.com/remote.pdf"
+    mock_response = MagicMock()
+    mock_response.status_code = 206
+    mock_response.content = b"partial-data"
+    mock_response.headers = {"Content-Range": "bytes 0-11/1000"}
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("ra_mcp_pdf_mcp.cache.httpx.AsyncClient", return_value=mock_client):
+        chunk, total = await read_pdf_range(url, 0, 12)
+
+    assert chunk == b"partial-data"
+    assert total == 1000
+
+
+async def test_read_pdf_range_http_206_unknown_size():
+    url = "https://example.com/remote.pdf"
+    mock_response = MagicMock()
+    mock_response.status_code = 206
+    mock_response.content = b"data"
+    mock_response.headers = {"Content-Range": "bytes 0-3/*"}
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("ra_mcp_pdf_mcp.cache.httpx.AsyncClient", return_value=mock_client):
+        chunk, total = await read_pdf_range(url, 0, 4)
+
+    assert chunk == b"data"
+    assert total == 0
+
+
+# ── read_pdf_range with full GET (200) ───────────────────────────────
+
+
+async def test_read_pdf_range_http_200_caches():
+    url = "https://example.com/full.pdf"
+    full_data = b"A" * 500
+
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = full_data
+    mock_response.headers = {"Content-Length": str(len(full_data))}
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("ra_mcp_pdf_mcp.cache.httpx.AsyncClient", return_value=mock_client):
+        chunk, total = await read_pdf_range(url, 10, 50)
+
+    assert chunk == full_data[10:60]
+    assert total == 500
+    assert pdf_cache[url] == full_data
+
+
+async def test_read_pdf_range_too_large_raises():
+    url = "https://example.com/huge.pdf"
+    mock_response = MagicMock()
+    mock_response.status_code = 200
+    mock_response.content = b"x"
+    mock_response.headers = {"Content-Length": str(MAX_PDF_SIZE + 1)}
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(return_value=mock_response)
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("ra_mcp_pdf_mcp.cache.httpx.AsyncClient", return_value=mock_client):
+        with pytest.raises(ValueError, match="too large"):
+            await read_pdf_range(url, 0, 100)
+
+
+# ── read_pdf_range with 501 fallback ─────────────────────────────────
+
+
+async def test_read_pdf_range_501_falls_back_to_full_get():
+    url = "https://example.com/no-range.pdf"
+    full_data = b"full-content-here"
+
+    resp_501 = MagicMock()
+    resp_501.status_code = 501
+
+    resp_200 = MagicMock()
+    resp_200.status_code = 200
+    resp_200.content = full_data
+    resp_200.headers = {"Content-Length": str(len(full_data))}
+    resp_200.raise_for_status = MagicMock()
+
+    mock_client = AsyncMock()
+    mock_client.get = AsyncMock(side_effect=[resp_501, resp_200])
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=None)
+
+    with patch("ra_mcp_pdf_mcp.cache.httpx.AsyncClient", return_value=mock_client):
+        chunk, total = await read_pdf_range(url, 0, 5)
+
+    assert chunk == b"full-"
+    assert total == len(full_data)

--- a/packages/pdf-mcp/tests/test_gallery.py
+++ b/packages/pdf-mcp/tests/test_gallery.py
@@ -1,0 +1,28 @@
+"""Tests for ra_mcp_pdf_mcp.gallery."""
+
+from ra_mcp_pdf_mcp.gallery import GALLERY_ITEMS, get_gallery_items
+
+
+def test_get_gallery_items_returns_list():
+    items = get_gallery_items()
+    assert isinstance(items, list)
+    assert len(items) > 0
+
+
+def test_gallery_items_have_required_keys():
+    for item in GALLERY_ITEMS:
+        assert "url" in item
+        assert "title" in item
+        assert "description" in item
+        assert "thumbnail_url" in item
+        assert "category" in item
+
+
+def test_gallery_urls_are_pdf_links():
+    for item in GALLERY_ITEMS:
+        assert ".pdf" in item["url"]
+        assert item["url"].startswith("https://")
+
+
+def test_get_gallery_items_returns_same_reference():
+    assert get_gallery_items() is GALLERY_ITEMS

--- a/packages/pdf-mcp/tests/test_models.py
+++ b/packages/pdf-mcp/tests/test_models.py
@@ -1,0 +1,118 @@
+"""Tests for ra_mcp_pdf_mcp.models."""
+
+import pytest
+
+from ra_mcp_pdf_mcp.models import MatchedBlock, PageMatch, PdfViewerState, SearchResult
+
+
+# ── PdfViewerState ───────────────────────────────────────────────────
+
+
+def test_pdf_viewer_state_defaults():
+    state = PdfViewerState()
+    assert state.view_id == ""
+    assert state.version == 0
+    assert state.url == ""
+    assert state.title == "Document"
+    assert state.current_page == 1
+    assert state.total_pages == 0
+    assert state.go_to_page == -1
+    assert state.search_term == ""
+    assert state.request_fullscreen is False
+
+
+def test_pdf_viewer_state_custom_fields():
+    state = PdfViewerState(
+        view_id="abc-123",
+        version=3,
+        url="https://example.com/doc.pdf",
+        title="My Doc",
+        current_page=5,
+        total_pages=100,
+    )
+    assert state.view_id == "abc-123"
+    assert state.version == 3
+    assert state.current_page == 5
+    assert state.total_pages == 100
+
+
+# ── MatchedBlock ─────────────────────────────────────────────────────
+
+
+def test_matched_block_to_structured():
+    block = MatchedBlock(
+        text="Trolldom i Norrland",
+        bbox=[72, 100, 400, 130],
+        block_type="Text",
+        match_count=2,
+    )
+    result = block.to_structured()
+    assert result == {
+        "text": "Trolldom i Norrland",
+        "bbox": [72, 100, 400, 130],
+        "blockType": "Text",
+        "matchCount": 2,
+    }
+
+
+# ── PageMatch ────────────────────────────────────────────────────────
+
+
+def test_page_match_to_structured():
+    block = MatchedBlock(text="text", bbox=[0, 0, 100, 50], block_type="Text", match_count=1)
+    pm = PageMatch(
+        page_index=0,
+        page_num=1,
+        match_count=1,
+        page_bbox=[0, 0, 595, 842],
+        blocks=[block],
+    )
+    result = pm.to_structured()
+    assert result["pageIndex"] == 0
+    assert result["pageNum"] == 1
+    assert result["matchCount"] == 1
+    assert result["pageBbox"] == [0, 0, 595, 842]
+    assert len(result["blocks"]) == 1
+    assert result["blocks"][0]["blockType"] == "Text"
+
+
+# ── SearchResult ─────────────────────────────────────────────────────
+
+
+def test_search_result_to_structured_empty():
+    sr = SearchResult(page_matches=[], total_matches=0)
+    result = sr.to_structured()
+    assert result == {"pageMatches": [], "totalMatches": 0}
+
+
+def test_search_result_to_structured_with_matches():
+    block = MatchedBlock(text="match", bbox=[0, 0, 10, 10], block_type="Text", match_count=1)
+    pm = PageMatch(page_index=2, page_num=3, match_count=1, page_bbox=[0, 0, 595, 842], blocks=[block])
+    sr = SearchResult(page_matches=[pm], total_matches=1)
+    result = sr.to_structured()
+    assert result["totalMatches"] == 1
+    assert len(result["pageMatches"]) == 1
+
+
+@pytest.mark.parametrize(
+    "total,term,expected_fragment",
+    [
+        pytest.param(1, "bok", "1 match for 'bok' across 1 page", id="singular"),
+        pytest.param(5, "bok", "5 matches for 'bok' across", id="plural"),
+    ],
+)
+def test_search_result_summary_grammar(total, term, expected_fragment):
+    blocks = [MatchedBlock(text=f"contains {term} here", bbox=[0, 0, 10, 10], block_type="Text", match_count=total)]
+    pm = PageMatch(page_index=0, page_num=1, match_count=total, page_bbox=[0, 0, 595, 842], blocks=blocks)
+    sr = SearchResult(page_matches=[pm], total_matches=total)
+    summary = sr.summary(term)
+    assert expected_fragment in summary
+
+
+def test_search_result_summary_truncates_at_10_snippets():
+    blocks = [MatchedBlock(text=f"block {i}", bbox=[0, 0, 10, 10], block_type="Text", match_count=1) for i in range(15)]
+    pms = [PageMatch(page_index=i, page_num=i + 1, match_count=1, page_bbox=[0, 0, 595, 842], blocks=[blocks[i]]) for i in range(15)]
+    sr = SearchResult(page_matches=pms, total_matches=15)
+    summary = sr.summary("term")
+    snippet_lines = [line for line in summary.split("\n") if line.strip().startswith("p.")]
+    assert len(snippet_lines) == 10

--- a/packages/pdf-mcp/tests/test_search.py
+++ b/packages/pdf-mcp/tests/test_search.py
@@ -1,0 +1,117 @@
+"""Tests for ra_mcp_pdf_mcp.search."""
+
+import pytest
+
+from ra_mcp_pdf_mcp.search import _count_occurrences, html_to_text, search_pages
+
+
+# ── html_to_text ─────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "html,expected",
+    [
+        pytest.param("<p>Hello world</p>", "Hello world", id="simple-p"),
+        pytest.param("<p>Bold <b>text</b> here</p>", "Bold  text  here", id="nested-tags"),
+        pytest.param("", "", id="empty"),
+        pytest.param("no tags at all", "no tags at all", id="no-html"),
+        pytest.param("<div><span>nested</span></div>", "nested", id="deeply-nested"),
+        pytest.param("<p>a &amp; b</p>", "a &amp; b", id="html-entities-passthrough"),
+    ],
+)
+def test_html_to_text(html, expected):
+    assert html_to_text(html) == expected
+
+
+# ── _count_occurrences ───────────────────────────────────────────────
+
+
+@pytest.mark.parametrize(
+    "text,term,expected",
+    [
+        pytest.param("hello world", "hello", 1, id="single-match"),
+        pytest.param("aaa", "a", 3, id="non-overlapping-single-char"),
+        pytest.param("abcabc", "abc", 2, id="repeated"),
+        pytest.param("nothing here", "xyz", 0, id="no-match"),
+        pytest.param("", "x", 0, id="empty-text"),
+        pytest.param("stockholm stockholm stockholm", "stockholm", 3, id="triple"),
+    ],
+)
+def test_count_occurrences(text, term, expected):
+    assert _count_occurrences(text, term) == expected
+
+
+# ── search_pages ─────────────────────────────────────────────────────
+
+
+def test_search_pages_finds_term(sample_pages):
+    result = search_pages(sample_pages, "Stockholm")
+    assert result.total_matches >= 1
+    page_nums = [pm.page_num for pm in result.page_matches]
+    assert 1 in page_nums
+
+
+def test_search_pages_case_insensitive(sample_pages):
+    lower = search_pages(sample_pages, "stockholm")
+    upper = search_pages(sample_pages, "STOCKHOLM")
+    assert lower.total_matches == upper.total_matches
+    assert lower.total_matches > 0
+
+
+def test_search_pages_no_match(sample_pages):
+    result = search_pages(sample_pages, "xyznonexistent")
+    assert result.total_matches == 0
+    assert result.page_matches == []
+
+
+def test_search_pages_multiple_pages(sample_pages):
+    result = search_pages(sample_pages, "Stockholm")
+    page_indices = [pm.page_index for pm in result.page_matches]
+    assert 0 in page_indices
+    assert 2 in page_indices
+
+
+def test_search_pages_counts_multiple_occurrences_in_block(sample_pages):
+    result = search_pages(sample_pages, "Stockholm")
+    page_2 = next(pm for pm in result.page_matches if pm.page_index == 2)
+    assert page_2.match_count == 3
+
+
+def test_search_pages_strips_html_before_matching(sample_pages):
+    result = search_pages(sample_pages, "beslut")
+    assert result.total_matches == 1
+    block = result.page_matches[0].blocks[0]
+    assert "<b>" not in block.text
+
+
+def test_search_pages_skips_empty_html(sample_pages):
+    result = search_pages(sample_pages, "Figure")
+    assert result.total_matches == 0
+
+
+def test_search_pages_truncates_block_text():
+    long_text = "x" * 500
+    pages = [
+        {
+            "page": 0,
+            "bbox": [0, 0, 595, 842],
+            "children": [
+                {"html": f"<p>{long_text}</p>", "bbox": [0, 0, 100, 50], "block_type": "Text"},
+            ],
+        }
+    ]
+    result = search_pages(pages, "x")
+    assert len(result.page_matches[0].blocks[0].text) <= 300
+
+
+def test_search_pages_empty_input():
+    result = search_pages([], "term")
+    assert result.total_matches == 0
+    assert result.page_matches == []
+
+
+def test_search_pages_preserves_bbox(sample_pages):
+    result = search_pages(sample_pages, "Kungliga")
+    block = result.page_matches[0].blocks[0]
+    assert block.bbox == [72, 100, 400, 130]
+    assert block.block_type == "SectionHeader"

--- a/packages/pdf-mcp/tests/test_state.py
+++ b/packages/pdf-mcp/tests/test_state.py
@@ -1,0 +1,65 @@
+"""Tests for ra_mcp_pdf_mcp.state."""
+
+import pytest
+
+from ra_mcp_pdf_mcp.models import PdfViewerState
+from ra_mcp_pdf_mcp.state import get_active_state, get_state, put_state
+import ra_mcp_pdf_mcp.state as _state_mod
+
+
+async def test_get_state_returns_default_for_unknown_id():
+    state = await get_state("nonexistent-id")
+    assert state.view_id == "nonexistent-id"
+    assert state.version == 0
+
+
+async def test_put_state_increments_version():
+    state = PdfViewerState(view_id="test-1", url="https://example.com/a.pdf")
+    result = await put_state(state)
+    assert result["version"] == 1
+
+    state2 = await get_state("test-1")
+    result2 = await put_state(state2)
+    assert result2["version"] == 2
+
+
+async def test_put_state_sets_latest_view_id():
+    state = PdfViewerState(view_id="view-abc", url="https://example.com/b.pdf")
+    await put_state(state)
+    assert _state_mod.latest_view_id == "view-abc"
+
+
+async def test_get_active_state_raises_when_no_viewer():
+    with pytest.raises(LookupError, match="No PDF viewer is open"):
+        await get_active_state()
+
+
+async def test_get_active_state_returns_latest():
+    state = PdfViewerState(view_id="active-1", url="https://example.com/c.pdf", title="Doc C")
+    await put_state(state)
+
+    active = await get_active_state()
+    assert active.view_id == "active-1"
+    assert active.title == "Doc C"
+    assert active.version == 1
+
+
+async def test_put_state_returns_dict_for_structured_content():
+    state = PdfViewerState(view_id="dict-test", url="https://example.com/d.pdf")
+    result = await put_state(state)
+    assert isinstance(result, dict)
+    assert result["view_id"] == "dict-test"
+    assert result["url"] == "https://example.com/d.pdf"
+
+
+async def test_multiple_views_are_independent():
+    state_a = PdfViewerState(view_id="view-a", url="https://a.pdf", title="A")
+    state_b = PdfViewerState(view_id="view-b", url="https://b.pdf", title="B")
+    await put_state(state_a)
+    await put_state(state_b)
+
+    retrieved_a = await get_state("view-a")
+    retrieved_b = await get_state("view-b")
+    assert retrieved_a.title == "A"
+    assert retrieved_b.title == "B"
+    assert _state_mod.latest_view_id == "view-b"

--- a/packages/pdf-mcp/tests/test_tools.py
+++ b/packages/pdf-mcp/tests/test_tools.py
@@ -1,0 +1,401 @@
+"""Integration tests for PDF MCP tools using FastMCP's in-memory test client."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastmcp import Client
+
+from ra_mcp_pdf_mcp import pdf_mcp as mcp
+from ra_mcp_pdf_mcp.cache import blocks_cache, pdf_cache
+import ra_mcp_pdf_mcp.state as _state_mod
+
+
+SAMPLE_URL = "https://huggingface.co/buckets/Riksarkivet/pdfs/resolve/test.pdf?download=true"
+
+SAMPLE_PAGES = [
+    {
+        "page": 0,
+        "bbox": [0, 0, 595, 842],
+        "children": [
+            {"html": "<p>Riksarkivets handlingar</p>", "bbox": [72, 100, 400, 130], "block_type": "SectionHeader"},
+            {"html": "<p>Stockholm 1723</p>", "bbox": [72, 140, 400, 160], "block_type": "Text"},
+        ],
+    },
+    {
+        "page": 1,
+        "bbox": [0, 0, 595, 842],
+        "children": [
+            {"html": "<p>Kapitel om trolldom och häxprocesser</p>", "bbox": [72, 100, 400, 130], "block_type": "Text"},
+        ],
+    },
+]
+
+
+# ── display_pdf ──────────────────────────────────────────────────────
+
+
+async def test_display_pdf_returns_view_id():
+    with patch("ra_mcp_pdf_mcp.tools.schedule_prefetch"):
+        async with Client(mcp) as client:
+            result = await client.call_tool("display_pdf", {"url": SAMPLE_URL})
+
+    assert not result.is_error
+    text = result.content[0].text
+    assert "view_uuid:" in text
+    assert result.structured_content["view_id"]
+    assert result.structured_content["url"] == SAMPLE_URL
+
+
+async def test_display_pdf_extracts_title_from_url():
+    with patch("ra_mcp_pdf_mcp.tools.schedule_prefetch"):
+        async with Client(mcp) as client:
+            result = await client.call_tool("display_pdf", {"url": SAMPLE_URL})
+
+    assert "test" in result.structured_content["title"].lower()
+
+
+async def test_display_pdf_uses_custom_title():
+    with patch("ra_mcp_pdf_mcp.tools.schedule_prefetch"):
+        async with Client(mcp) as client:
+            result = await client.call_tool("display_pdf", {"url": SAMPLE_URL, "title": "Custom Title"})
+
+    assert result.structured_content["title"] == "Custom Title"
+
+
+async def test_display_pdf_empty_url_returns_error():
+    with patch("ra_mcp_pdf_mcp.tools.schedule_prefetch"):
+        async with Client(mcp) as client:
+            result = await client.call_tool("display_pdf", {"url": ""})
+
+    text = result.content[0].text
+    assert "Error" in text
+
+
+# ── get_pdf_state ────────────────────────────────────────────────────
+
+
+async def test_get_pdf_state_returns_stored_state():
+    with patch("ra_mcp_pdf_mcp.tools.schedule_prefetch"):
+        async with Client(mcp) as client:
+            doc = await client.call_tool("display_pdf", {"url": SAMPLE_URL})
+            view_id = doc.structured_content["view_id"]
+
+            result = await client.call_tool("get_pdf_state", {"view_id": view_id})
+
+    assert result.structured_content["version"] == 1
+    assert result.structured_content["url"] == SAMPLE_URL
+
+
+async def test_get_pdf_state_unknown_id_returns_defaults():
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_pdf_state", {"view_id": "unknown-id"})
+
+    assert result.structured_content["version"] == 0
+    assert result.structured_content["url"] == ""
+
+
+# ── pdf_set_search ───────────────────────────────────────────────────
+
+
+async def test_pdf_set_search_updates_state():
+    with patch("ra_mcp_pdf_mcp.tools.schedule_prefetch"):
+        async with Client(mcp) as client:
+            doc = await client.call_tool("display_pdf", {"url": SAMPLE_URL})
+            view_id = doc.structured_content["view_id"]
+
+            result = await client.call_tool("pdf_set_search", {"search_term": "trolldom"})
+
+    assert not result.is_error
+    assert "Highlighting" in result.content[0].text
+
+    async with Client(mcp) as client:
+        state = await client.call_tool("get_pdf_state", {"view_id": view_id})
+    assert state.structured_content["search_term"] == "trolldom"
+
+
+async def test_pdf_set_search_without_viewer_returns_error():
+    async with Client(mcp) as client:
+        result = await client.call_tool("pdf_set_search", {"search_term": "test"})
+
+    text = result.content[0].text
+    assert "Error" in text
+    assert "display_pdf" in text.lower() or "viewer" in text.lower()
+
+
+async def test_pdf_set_search_clear():
+    with patch("ra_mcp_pdf_mcp.tools.schedule_prefetch"):
+        async with Client(mcp) as client:
+            await client.call_tool("display_pdf", {"url": SAMPLE_URL})
+            result = await client.call_tool("pdf_set_search", {"search_term": ""})
+
+    assert "Cleared" in result.content[0].text
+
+
+# ── pdf_go_to_page ───────────────────────────────────────────────────
+
+
+async def test_pdf_go_to_page_updates_state():
+    with patch("ra_mcp_pdf_mcp.tools.schedule_prefetch"):
+        async with Client(mcp) as client:
+            doc = await client.call_tool("display_pdf", {"url": SAMPLE_URL})
+            view_id = doc.structured_content["view_id"]
+
+            result = await client.call_tool("pdf_go_to_page", {"page": 5})
+
+    assert not result.is_error
+    assert "page 5" in result.content[0].text.lower()
+
+    async with Client(mcp) as client:
+        state = await client.call_tool("get_pdf_state", {"view_id": view_id})
+    assert state.structured_content["go_to_page"] == 4  # 0-based
+
+
+async def test_pdf_go_to_page_without_viewer_returns_error():
+    async with Client(mcp) as client:
+        result = await client.call_tool("pdf_go_to_page", {"page": 1})
+
+    text = result.content[0].text
+    assert "Error" in text
+
+
+# ── search_pdf ───────────────────────────────────────────────────────
+
+
+async def test_search_pdf_finds_matches():
+    blocks_cache[SAMPLE_URL] = SAMPLE_PAGES
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("search_pdf", {"url": SAMPLE_URL, "term": "Stockholm"})
+
+    assert not result.is_error
+    sc = result.structured_content
+    assert sc["totalMatches"] >= 1
+    assert len(sc["pageMatches"]) >= 1
+
+
+async def test_search_pdf_no_matches():
+    blocks_cache[SAMPLE_URL] = SAMPLE_PAGES
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("search_pdf", {"url": SAMPLE_URL, "term": "xyznonexistent"})
+
+    sc = result.structured_content
+    assert sc["totalMatches"] == 0
+    assert sc["pageMatches"] == []
+
+
+async def test_search_pdf_empty_term():
+    blocks_cache[SAMPLE_URL] = SAMPLE_PAGES
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("search_pdf", {"url": SAMPLE_URL, "term": ""})
+
+    sc = result.structured_content
+    assert sc["totalMatches"] == 0
+
+
+async def test_search_pdf_not_loaded():
+    async with Client(mcp) as client:
+        result = await client.call_tool("search_pdf", {"url": "https://example.com/missing.pdf", "term": "test"})
+
+    text = result.content[0].text
+    assert "Error" in text
+
+
+# ── read_pdf_page ────────────────────────────────────────────────────
+
+
+async def test_read_pdf_page_returns_text():
+    blocks_cache[SAMPLE_URL] = SAMPLE_PAGES
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("read_pdf_page", {"url": SAMPLE_URL, "page": 1})
+
+    assert not result.is_error
+    text = result.content[0].text
+    assert "Riksarkivets handlingar" in text
+    assert "Page 1/" in text
+
+
+async def test_read_pdf_page_multi_page():
+    blocks_cache[SAMPLE_URL] = SAMPLE_PAGES
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("read_pdf_page", {"url": SAMPLE_URL, "page": 1, "count": 2})
+
+    text = result.content[0].text
+    assert "Page 1/" in text
+    assert "Page 2/" in text
+    assert "trolldom" in text
+
+
+async def test_read_pdf_page_count_clamped_to_5():
+    blocks_cache[SAMPLE_URL] = SAMPLE_PAGES
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("read_pdf_page", {"url": SAMPLE_URL, "page": 1, "count": 100})
+
+    text = result.content[0].text
+    assert "Page 1/" in text
+    assert "Page 2/" in text
+
+
+async def test_read_pdf_page_not_loaded():
+    with patch("ra_mcp_pdf_mcp.cache.preload_all_guides", new_callable=AsyncMock):
+        async with Client(mcp) as client:
+            result = await client.call_tool("read_pdf_page", {"url": "https://example.com/missing.pdf", "page": 1})
+
+    text = result.content[0].text
+    assert "Error" in text
+
+
+async def test_read_pdf_page_section_header_formatted():
+    blocks_cache[SAMPLE_URL] = SAMPLE_PAGES
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("read_pdf_page", {"url": SAMPLE_URL, "page": 1})
+
+    text = result.content[0].text
+    assert "## Riksarkivets handlingar" in text
+
+
+# ── get_page_blocks ──────────────────────────────────────────────────
+
+
+async def test_get_page_blocks_returns_blocks():
+    blocks_cache[SAMPLE_URL] = SAMPLE_PAGES
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_page_blocks", {"url": SAMPLE_URL, "page": 1})
+
+    assert not result.is_error
+    sc = result.structured_content
+    assert "blocks" in sc
+    assert len(sc["blocks"]) == 2
+    assert sc["pageBbox"] == [0, 0, 595, 842]
+    assert sc["blocks"][0]["blockType"] == "SectionHeader"
+
+
+async def test_get_page_blocks_not_loaded():
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_page_blocks", {"url": "https://x.com/missing.pdf", "page": 1})
+
+    text = result.content[0].text
+    assert "Error" in text
+
+
+async def test_get_page_blocks_out_of_range():
+    blocks_cache[SAMPLE_URL] = SAMPLE_PAGES
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("get_page_blocks", {"url": SAMPLE_URL, "page": 99})
+
+    text = result.content[0].text
+    assert "Error" in text
+    assert "out of range" in text.lower()
+
+
+# ── list_pdfs ────────────────────────────────────────────────────────
+
+
+async def test_list_pdfs_returns_gallery():
+    async with Client(mcp) as client:
+        result = await client.call_tool("list_pdfs", {})
+
+    assert not result.is_error
+    text = result.content[0].text
+    assert "PDF guides available" in text
+    sc = result.structured_content
+    assert "items" in sc
+    assert len(sc["items"]) > 0
+    assert "url" in sc["items"][0]
+
+
+# ── search_guides ────────────────────────────────────────────────────
+
+
+async def test_search_guides_finds_across_multiple():
+    from ra_mcp_pdf_mcp.gallery import GALLERY_ITEMS
+
+    for item in GALLERY_ITEMS:
+        blocks_cache[item["url"]] = SAMPLE_PAGES
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("search_guides", {"term": "Stockholm"})
+
+    assert not result.is_error
+    text = result.content[0].text
+    assert "matches" in text.lower()
+    assert "Stockholm" in text
+
+
+async def test_search_guides_empty_term():
+    async with Client(mcp) as client:
+        result = await client.call_tool("search_guides", {"term": ""})
+
+    text = result.content[0].text
+    assert "no search term" in text.lower()
+
+
+async def test_search_guides_no_matches():
+    from ra_mcp_pdf_mcp.gallery import GALLERY_ITEMS
+
+    for item in GALLERY_ITEMS:
+        blocks_cache[item["url"]] = SAMPLE_PAGES
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("search_guides", {"term": "xyznonexistent123"})
+
+    text = result.content[0].text
+    assert "No matches" in text
+
+
+# ── read_pdf_bytes ───────────────────────────────────────────────────
+
+
+async def test_read_pdf_bytes_returns_base64():
+    pdf_cache[SAMPLE_URL] = b"fake-pdf-content-1234567890"
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("read_pdf_bytes", {"url": SAMPLE_URL, "offset": 0})
+
+    assert not result.is_error
+    sc = result.structured_content
+    assert "bytes" in sc
+    assert sc["offset"] == 0
+    assert sc["byteCount"] > 0
+    assert isinstance(sc["hasMore"], bool)
+
+
+async def test_read_pdf_bytes_with_offset():
+    data = b"A" * 100
+    pdf_cache[SAMPLE_URL] = data
+
+    async with Client(mcp) as client:
+        result = await client.call_tool("read_pdf_bytes", {"url": SAMPLE_URL, "offset": 50})
+
+    sc = result.structured_content
+    assert sc["offset"] == 50
+    assert sc["byteCount"] == 50
+
+
+# ── Multi-view isolation ─────────────────────────────────────────────
+
+
+async def test_multiple_display_pdf_creates_independent_views():
+    with patch("ra_mcp_pdf_mcp.tools.schedule_prefetch"):
+        async with Client(mcp) as client:
+            doc_a = await client.call_tool("display_pdf", {"url": SAMPLE_URL, "title": "Doc A"})
+            doc_b = await client.call_tool("display_pdf", {"url": SAMPLE_URL, "title": "Doc B"})
+
+            view_a = doc_a.structured_content["view_id"]
+            view_b = doc_b.structured_content["view_id"]
+            assert view_a != view_b
+
+            await client.call_tool("pdf_set_search", {"search_term": "latest"})
+
+            state_a = await client.call_tool("get_pdf_state", {"view_id": view_a})
+            state_b = await client.call_tool("get_pdf_state", {"view_id": view_b})
+
+    assert state_a.structured_content["search_term"] == ""
+    assert state_b.structured_content["search_term"] == "latest"


### PR DESCRIPTION
Adds test suite for the pdf-mcp package, which previously had no test coverage.

## What's included

- **test_models.py** (9 tests) — PdfViewerState defaults, MatchedBlock/PageMatch/SearchResult structured output
- **test_search.py** (10 tests) — html_to_text, occurrence counting, search across pages with case insensitivity and HTML stripping
- **test_cache.py** (12 tests) — URL construction, PDF range reading with HTTP 206/200/501 paths and size limits
- **test_gallery.py** (4 tests) — Gallery structure, required keys, URL validation
- **test_state.py** (7 tests) — State management: versioning, LookupError, multi-view isolation
- **test_tools.py** (22 tests) — All MCP tools via fastmcp Client: display_pdf, search, navigation, page reading, multi-view
- **conftest.py** — Auto-reset of module-level state and shared fixtures

## Details
- 84 tests, all passing
- Follows testing patterns from CLAUDE.md
- No changes to production code