### PR TITLE
docs: refresh README and docs to match current 44-package layout

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,22 +8,38 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ### Architecture
 
-The project is organized as a **uv workspace** with eight modular packages plus a root server:
+The project is organized as a **uv workspace** with 44 packages under `packages/` plus a root server.
+Packages follow a naming convention by role:
+
+- `*-lib` — domain libraries (models, clients, operations), plus `common`
+- `*-mcp` — FastMCP servers that wrap a domain library as MCP tools/resources
+- `search-cli` / `browse-cli` / `tui` — CLI and terminal-UI front-ends
 
 ```
 ra-mcp/
 ├── src/ra_mcp_server/          # Root: Server composition and main CLI
-│   ├── server.py               # FastMCP composition entry point
+│   ├── server.py               # FastMCP composition entry point + AVAILABLE_MODULES registry
 │   └── cli/app.py              # Typer CLI root (ra command)
 ├── packages/
-│   ├── common/                 # ra-mcp-common: Shared HTTP client and utilities
-│   ├── search/                 # ra-mcp-search: Search domain (models, clients, operations)
-│   ├── browse/                 # ra-mcp-browse: Browse domain (models, clients, operations)
+│   ├── common/                 # ra-mcp-common: Shared HTTP client, formatting, datasets, telemetry
+│   ├── xml-lib/                # ra-mcp-xml: ALTOClient (ALTO XML parsing)
+│   ├── iiif-lib/               # ra-mcp-iiif-lib: IIIFClient
+│   ├── oai-pmh-lib/            # ra-mcp-oai-pmh-lib: OAIPMHClient
+│   ├── search-lib/             # ra-mcp-search-lib: Search domain (models, client, operations)
+│   ├── browse-lib/             # ra-mcp-browse-lib: Browse domain (models, operations, url_generator)
 │   ├── search-mcp/             # ra-mcp-search-mcp: MCP tools for search
 │   ├── browse-mcp/             # ra-mcp-browse-mcp: MCP tool for browse
+│   ├── guide-mcp/              # ra-mcp-guide-mcp: MCP resources for historical guides
+│   ├── htr-mcp/                # ra-mcp-htr-mcp: Handwritten text recognition (HTRflow)
+│   ├── viewer-mcp/             # ra-mcp-viewer-mcp: Interactive document viewer (MCP App UI)
+│   ├── pdf-mcp/                # ra-mcp-pdf-mcp: Interactive PDF viewer (MCP App UI)
+│   ├── label-mcp/              # ra-mcp-label-mcp: Label Studio import (optional)
 │   ├── search-cli/             # ra-mcp-search-cli: CLI command for search
 │   ├── browse-cli/             # ra-mcp-browse-cli: CLI command for browse
-│   └── guide-mcp/              # ra-mcp-guide-mcp: MCP resources for historical guides
+│   ├── tui/                    # ra-mcp-tui: Interactive terminal browser
+│   └── <dataset>-lib/-mcp/     # 13 LanceDB dataset packages (diplomatics, sbl, sjomanshus,
+│                               #   filmcensur, rosenberg, court, aktiebolag, faltjagare,
+│                               #   suffrage, specialsok, dds, wincars, sj) + tora geocoding
 ├── resources/                  # Historical guide markdown files
 ├── pyproject.toml              # Workspace configuration
 └── uv.lock                     # Shared lockfile
@@ -32,66 +48,79 @@ ra-mcp/
 ### Package Structure
 
 **ra-mcp-common** (no internal dependencies):
-- [http_client.py](packages/common/src/ra_mcp_common/utils/http_client.py): Centralized urllib-based HTTP client with logging
+- [http_client.py](packages/common/src/ra_mcp_common/http_client.py): Centralized httpx-based async HTTP client with logging
+- [formatting.py](packages/common/src/ra_mcp_common/formatting.py), [datasets.py](packages/common/src/ra_mcp_common/datasets.py), [telemetry.py](packages/common/src/ra_mcp_common/telemetry.py)
 
-**ra-mcp-search** (depends on common):
-- [config.py](packages/search/src/ra_mcp_search/config.py): Search API URL and constants
-- [models.py](packages/search/src/ra_mcp_search/models.py): Pydantic models (SearchRecord, RecordsResponse, SearchResult)
-- [clients/search_client.py](packages/search/src/ra_mcp_search/clients/search_client.py): SearchAPI client
-- [operations/search_operations.py](packages/search/src/ra_mcp_search/operations/search_operations.py): Search business logic
+**Shared client libs** (depend on common): the ALTO/IIIF/OAI-PMH clients were extracted out of browse into their own packages so any package can reuse them:
+- [ra-mcp-xml](packages/xml-lib/src/ra_mcp_xml/client.py): `ALTOClient` (ALTO XML fetching + parsing)
+- [ra-mcp-iiif-lib](packages/iiif-lib/src/ra_mcp_iiif_lib/client.py): `IIIFClient`
+- [ra-mcp-oai-pmh-lib](packages/oai-pmh-lib/src/ra_mcp_oai_pmh_lib/client.py): `OAIPMHClient`
 
-**ra-mcp-browse** (depends on common):
-- [config.py](packages/browse/src/ra_mcp_browse/config.py): Browse API URLs and constants
-- [models.py](packages/browse/src/ra_mcp_browse/models.py): Pydantic models (BrowseResult, PageContext)
-- [clients/](packages/browse/src/ra_mcp_browse/clients/): API clients (ALTOClient, IIIFClient, OAIPMHClient)
-- [operations/browse_operations.py](packages/browse/src/ra_mcp_browse/operations/browse_operations.py): Browse business logic
-- [url_generator.py](packages/browse/src/ra_mcp_browse/url_generator.py): URL construction helpers
+**ra-mcp-search-lib** (module `ra_mcp_search_lib`, depends on common):
+- [config.py](packages/search-lib/src/ra_mcp_search_lib/config.py): Search API URL and constants
+- [models.py](packages/search-lib/src/ra_mcp_search_lib/models.py): Pydantic models (SearchRecord, RecordsResponse, SearchResult)
+- [search_client.py](packages/search-lib/src/ra_mcp_search_lib/search_client.py): SearchClient client
+- [search_operations.py](packages/search-lib/src/ra_mcp_search_lib/search_operations.py): Search business logic
 
-**ra-mcp-search-mcp** (depends on search + fastmcp):
+**ra-mcp-browse-lib** (module `ra_mcp_browse_lib`, depends on common + xml/iiif/oai-pmh libs):
+- [config.py](packages/browse-lib/src/ra_mcp_browse_lib/config.py): Browse API URLs and constants
+- [models.py](packages/browse-lib/src/ra_mcp_browse_lib/models.py): Pydantic models (BrowseResult, PageContext)
+- [browse_operations.py](packages/browse-lib/src/ra_mcp_browse_lib/browse_operations.py): Browse business logic (uses ALTOClient, IIIFClient, OAIPMHClient)
+- [url_generator.py](packages/browse-lib/src/ra_mcp_browse_lib/url_generator.py): URL construction helpers
+
+**ra-mcp-search-mcp** (depends on search-lib + fastmcp):
 - [tools.py](packages/search-mcp/src/ra_mcp_search_mcp/tools.py): FastMCP server setup, instructions, and tool registration
 - [search_tool.py](packages/search-mcp/src/ra_mcp_search_mcp/search_tool.py): `search_transcribed` and `search_metadata` MCP tools
 - [server.py](packages/search-mcp/src/ra_mcp_search_mcp/server.py): Standalone entry point for isolated dev/testing
 - [formatter.py](packages/search-mcp/src/ra_mcp_search_mcp/formatter.py): Search result formatting for LLM output
 
-**ra-mcp-browse-mcp** (depends on browse + fastmcp):
+**ra-mcp-browse-mcp** (depends on browse-lib + fastmcp):
 - [tools.py](packages/browse-mcp/src/ra_mcp_browse_mcp/tools.py): FastMCP server setup, instructions, and tool registration
 - [browse_tool.py](packages/browse-mcp/src/ra_mcp_browse_mcp/browse_tool.py): `browse_document` MCP tool
 - [server.py](packages/browse-mcp/src/ra_mcp_browse_mcp/server.py): Standalone entry point for isolated dev/testing
 - [formatter.py](packages/browse-mcp/src/ra_mcp_browse_mcp/formatter.py): Browse result formatting for LLM output
 
-**ra-mcp-search-cli** (depends on search + typer + rich):
-- [app.py](packages/search-cli/src/search_cli/app.py): Typer sub-app
-- [search_cmd.py](packages/search-cli/src/search_cli/search_cmd.py): `ra search` CLI command
+**ra-mcp-search-cli** (module `ra_mcp_search_cli`, depends on search-lib + typer + rich):
+- [app.py](packages/search-cli/src/ra_mcp_search_cli/app.py): Typer sub-app (`search_app`)
+- [search_cmd.py](packages/search-cli/src/ra_mcp_search_cli/search_cmd.py): `ra search` CLI command
 - [formatter.py](packages/search-cli/src/ra_mcp_search_cli/formatter.py): CLI output formatting
 
-**ra-mcp-browse-cli** (depends on browse + typer + rich):
-- [app.py](packages/browse-cli/src/ra_mcp_browse_cli/app.py): Typer sub-app
+**ra-mcp-browse-cli** (module `ra_mcp_browse_cli`, depends on browse-lib + typer + rich):
+- [app.py](packages/browse-cli/src/ra_mcp_browse_cli/app.py): Typer sub-app (`browse_app`)
 - [browse_cmd.py](packages/browse-cli/src/ra_mcp_browse_cli/browse_cmd.py): `ra browse` CLI command
 - [formatter.py](packages/browse-cli/src/ra_mcp_browse_cli/formatter.py): CLI output formatting
+
+**ra-mcp-tui** (module `ra_mcp_tui`): Textual-based interactive terminal browser (`tui_app`, `ra tui`).
 
 **ra-mcp-guide-mcp** (depends on common + fastmcp):
 - [tools.py](packages/guide-mcp/src/ra_mcp_guide_mcp/tools.py): FastMCP server and MCP resources for historical guides from `resources/`
 - [server.py](packages/guide-mcp/src/ra_mcp_guide_mcp/server.py): Standalone entry point for isolated dev/testing
 
-**Root package — ra-mcp** (depends on all MCP and CLI packages):
-- [server.py](src/ra_mcp_server/server.py): FastMCP composition server (imports search, browse, guide modules)
-- [cli/app.py](src/ra_mcp_server/cli/app.py): Main Typer CLI entry point (`ra` command)
+**Dataset / feature MCP modules**: `htr-mcp`, `viewer-mcp`, `pdf-mcp`, `label-mcp`, and 13 LanceDB-backed dataset modules (each a `<name>-lib` + `<name>-mcp` pair): diplomatics, sbl, sjomanshus, filmcensur, rosenberg, court, aktiebolag, faltjagare, suffrage, specialsok, dds, wincars, sj, plus `tora` geocoding. These follow the same lib/mcp split.
+
+**Root package — ra-mcp** (depends on all always-on MCP packages; dataset + CLI packages are optional extras):
+- [server.py](src/ra_mcp_server/server.py): FastMCP composition server with the `AVAILABLE_MODULES` registry (imports the always-on modules eagerly, optional modules via guarded `try`/`import`)
+- [cli/app.py](src/ra_mcp_server/cli/app.py): Main Typer CLI entry point (`ra` command). Note it imports `search_app`, `browse_app`, and `tui_app` unconditionally, so the `ra` command requires the `cli` and `tui` extras to be installed.
 
 ### Package Dependencies
 
 ```
-ra-mcp-common              (no internal deps)
+ra-mcp-common                              (no internal deps)
        ↑
-ra-mcp-search              (depends on common)
-ra-mcp-browse              (depends on common)
+ra-mcp-xml / iiif-lib / oai-pmh-lib        (depend on common)
+ra-mcp-search-lib                          (depends on common)
+ra-mcp-browse-lib                          (depends on common + xml/iiif/oai-pmh libs)
+<dataset>-lib                              (depend on common)
        ↑
-ra-mcp-search-mcp          (depends on search + fastmcp)
-ra-mcp-browse-mcp          (depends on browse + fastmcp)
-ra-mcp-guide-mcp           (depends on common + fastmcp)
-ra-mcp-search-cli          (depends on search + typer + rich)
-ra-mcp-browse-cli          (depends on browse + typer + rich)
+ra-mcp-search-mcp                          (depends on search-lib + fastmcp)
+ra-mcp-browse-mcp                          (depends on browse-lib + fastmcp)
+ra-mcp-guide-mcp / htr-mcp / viewer-mcp …  (depend on common/<dataset>-lib + fastmcp)
+<dataset>-mcp                              (depend on <dataset>-lib + fastmcp)
+ra-mcp-search-cli                          (depends on search-lib + typer + rich)
+ra-mcp-browse-cli                          (depends on browse-lib + typer + rich)
+ra-mcp-tui                                 (depends on search-lib/browse-lib + textual)
        ↑
-ra-mcp (root)              (composes all MCP and CLI packages)
+ra-mcp (root)                              (composes the MCP modules; CLI/TUI/dataset packages are optional extras)
 ```
 
 ## Development Workflow
@@ -105,7 +134,14 @@ cd ra-mcp
 
 # Install dependencies (syncs workspace packages)
 uv sync
+
+# Build the viewer-mcp and pdf-mcp App UIs (npm build of both UIs).
+# Required before `ra serve`, or the MCP App UIs won't be built.
+make build-ui
 ```
+
+The `make serve` / `make serve-http` targets run `build-ui` automatically. If you launch the
+server directly with `uv run ra serve`, run `make build-ui` yourself first.
 
 ### Running the Server
 
@@ -193,11 +229,11 @@ uv run pytest
 
 # Run specific package tests
 uv run pytest packages/common/tests/ -v
-uv run pytest packages/search/tests/ -v
-uv run pytest packages/browse/tests/ -v
+uv run pytest packages/search-lib/tests/ -v
+uv run pytest packages/browse-lib/tests/ -v
 
 # Run with coverage
-uv run pytest --cov=ra_mcp_common --cov=ra_mcp_search --cov=ra_mcp_browse --cov-report=html
+uv run pytest --cov=ra_mcp_common --cov=ra_mcp_search_lib --cov=ra_mcp_browse_lib --cov-report=html
 ```
 
 ### Testing Principles
@@ -205,10 +241,11 @@ uv run pytest --cov=ra_mcp_common --cov=ra_mcp_search --cov=ra_mcp_browse --cov-
 Tests follow patterns drawn from httpx, pydantic, and FastMCP. Build bottom-up through the dependency stack:
 
 ```
-Layer 0: ra-mcp-common           ← pure utilities, no internal deps
-Layer 1: ra-mcp-search, browse   ← domain models, clients, operations
-Layer 2: *-mcp, *-cli packages   ← MCP tools, CLI commands
-Layer 3: ra-mcp root server      ← composition
+Layer 0: ra-mcp-common               ← pure utilities, no internal deps
+Layer 1: *-lib packages              ← domain models, clients, operations
+         (xml, iiif-lib, oai-pmh-lib, search-lib, browse-lib, <dataset>-lib)
+Layer 2: *-mcp, *-cli, tui packages  ← MCP tools, CLI commands, terminal UI
+Layer 3: ra-mcp root server          ← composition
 ```
 
 **Structure:**
@@ -230,7 +267,7 @@ def test_page_id_to_number(page_id, expected):
 ```
 
 **Mock at the right boundary:**
-- Domain packages (search, browse): inject a mock `HTTPClient` via constructor — don't patch `urllib`
+- Domain libs (search-lib, browse-lib, the client libs): inject a mock `HTTPClient` via constructor — don't patch `httpx`
 - MCP tool packages: use `Client(mcp)` for in-process testing, mock at the operations layer
 - Never mock telemetry — test behavior, not instrumentation
 
@@ -424,33 +461,33 @@ dagger call publish-docker \
   --docker-username=env:DOCKER_USERNAME \
   --docker-password=env:DOCKER_PASSWORD \
   --image-repository="riksarkivet/ra-mcp" \
-  --tag="v0.3.0" \
+  --tag="v0.14.2" \
   --base-image="python:3.13-alpine" \
   --tag-suffix="-alpine" \
   --source=.
-# Result: riksarkivet/ra-mcp:v0.3.0-alpine
+# Result: riksarkivet/ra-mcp:v0.14.2-alpine
 
 # Publish Wolfi/Chainguard variant
 dagger call publish-docker \
   --docker-username=env:DOCKER_USERNAME \
   --docker-password=env:DOCKER_PASSWORD \
   --image-repository="riksarkivet/ra-mcp" \
-  --tag="v0.3.0" \
+  --tag="v0.14.2" \
   --base-image="cgr.dev/chainguard/python:latest-dev" \
   --tag-suffix="-wolfi" \
   --source=.
-# Result: riksarkivet/ra-mcp:v0.3.0-wolfi
+# Result: riksarkivet/ra-mcp:v0.14.2-wolfi
 
 # Publish Debian slim variant
 dagger call publish-docker \
   --docker-username=env:DOCKER_USERNAME \
   --docker-password=env:DOCKER_PASSWORD \
   --image-repository="riksarkivet/ra-mcp" \
-  --tag="v0.3.0" \
+  --tag="v0.14.2" \
   --base-image="python:3.13-slim" \
   --tag-suffix="-slim" \
   --source=.
-# Result: riksarkivet/ra-mcp:v0.3.0-slim
+# Result: riksarkivet/ra-mcp:v0.14.2-slim
 
 # Auto-tag from pyproject.toml version (prefixes with "v")
 dagger call publish-docker \
@@ -467,25 +504,25 @@ dagger call publish-docker \
 The publishing workflow ([publish.yml](.github/workflows/publish.yml)) uses `docker/build-push-action` for **native BuildKit attestation support**:
 
 1. **Publishes container images with embedded attestations:**
-   - Alpine: `riksarkivet/ra-mcp:v0.3.0-alpine`
-   - Wolfi: `riksarkivet/ra-mcp:v0.3.0-wolfi`
+   - Alpine: `riksarkivet/ra-mcp:v0.14.2-alpine`
+   - Wolfi: `riksarkivet/ra-mcp:v0.14.2-wolfi`
    - **SBOM attestations** embedded in registry manifest
    - **SLSA Provenance** (mode=max) embedded in registry
 
 2. **Also generates standalone SBOM files:**
-   - `sbom-v0.3.0-alpine.spdx.json` (as release asset)
-   - `sbom-v0.3.0-wolfi.spdx.json` (as release asset)
+   - `sbom-v0.14.2-alpine.spdx.json` (as release asset)
+   - `sbom-v0.14.2-wolfi.spdx.json` (as release asset)
 
 **Verify registry attestations:**
 ```bash
 # Inspect SBOM in registry
-docker buildx imagetools inspect riksarkivet/ra-mcp:v0.3.0-alpine --format "{{json .SBOM}}"
+docker buildx imagetools inspect riksarkivet/ra-mcp:v0.14.2-alpine --format "{{json .SBOM}}"
 
 # Inspect provenance
-docker buildx imagetools inspect riksarkivet/ra-mcp:v0.3.0-alpine --format "{{json .Provenance}}"
+docker buildx imagetools inspect riksarkivet/ra-mcp:v0.14.2-alpine --format "{{json .Provenance}}"
 
 # Verify with Docker Scout
-docker scout attestation riksarkivet/ra-mcp:v0.3.0-alpine
+docker scout attestation riksarkivet/ra-mcp:v0.14.2-alpine
 ```
 
 **Security Benefits:**
@@ -559,13 +596,22 @@ Add to `claude_desktop_config.json`:
 
 ## API Endpoints
 
-### Current Integrations
+### Live HTTP APIs (Riksarkivet)
+The search/browse/viewer modules call these remote services directly:
 - **Search API**: `https://data.riksarkivet.se/api/records` - [Documentation](https://github.com/Riksarkivet/dataplattform/wiki/Search-API)
 - **IIIF Collections**: `https://lbiiif.riksarkivet.se/collection/arkiv` - [Documentation](https://github.com/Riksarkivet/dataplattform/wiki/IIIF)
 - **IIIF Images**: `https://lbiiif.riksarkivet.se`
 - **ALTO XML**: `https://sok.riksarkivet.se/dokument/alto`
 - **Bildvisning**: `https://sok.riksarkivet.se/bildvisning` (Interactive viewer)
 - **OAI-PMH**: `https://oai-pmh.riksarkivet.se/OAI` - [Documentation](https://github.com/Riksarkivet/dataplattform/wiki/OAI-PMH)
+
+### Local LanceDB dataset modules
+In addition to the live HTTP APIs above, the server registers optional dataset modules that query
+**local LanceDB indexes** (no remote API) rather than the Riksarkivet HTTP endpoints: diplomatics,
+sbl, sjomanshus, filmcensur, rosenberg, court, aktiebolag, faltjagare, suffrage, specialsok, dds,
+wincars, sj. Each ships as a `<name>-lib` (data access) + `<name>-mcp` (tools) pair and is registered
+via a guarded `try`/`import` in `AVAILABLE_MODULES` (see [server.py](src/ra_mcp_server/server.py)), so a
+missing `lancedb` wheel just skips the module instead of breaking startup.
 
 ### Additional Resources
 - **[Riksarkivet Data Platform Wiki](https://github.com/Riksarkivet/dataplattform/wiki)**: Comprehensive API documentation
@@ -577,12 +623,12 @@ Add to `claude_desktop_config.json`:
 
 ### Adding a New MCP Tool
 
-1. Create a new tool file in the appropriate MCP package (e.g., [search_tool.py](packages/search-mcp/src/search_mcp/search_tool.py))
+1. Create a new tool file in the appropriate MCP package (e.g., [search_tool.py](packages/search-mcp/src/ra_mcp_search_mcp/search_tool.py))
 2. Define a `register_*_tool(mcp)` function that uses `@mcp.tool()` decorator
 3. Add detailed docstring with examples and parameter documentation
 4. Call the register function from the package's [tools.py](packages/search-mcp/src/ra_mcp_search_mcp/tools.py)
 
-Example pattern (from [search_tool.py](packages/search-mcp/src/search_mcp/search_tool.py)):
+Example pattern (from [search_tool.py](packages/search-mcp/src/ra_mcp_search_mcp/search_tool.py)):
 ```python
 def register_search_tool(mcp: FastMCP):
     @mcp.tool()
@@ -595,30 +641,58 @@ def register_search_tool(mcp: FastMCP):
 
 To add a new module (e.g., `ra-mcp-metadata`):
 
-1. Create domain package: `packages/metadata/` with models, clients, operations
-2. Create MCP package: `packages/metadata-mcp/` with tool registration
-3. Optionally create CLI package: `packages/metadata-cli/`
-4. Register in [server.py](src/ra_mcp_server/server.py) `AVAILABLE_MODULES`:
+1. Create domain lib package: `packages/metadata-lib/` (module `ra_mcp_metadata_lib`) with models, client, operations
+2. Create MCP package: `packages/metadata-mcp/` (module `ra_mcp_metadata_mcp`) exposing a FastMCP server (e.g. `metadata_mcp`)
+3. Register the workspace member + source mapping in the root [pyproject.toml](pyproject.toml):
+   - add `ra-mcp-metadata-mcp` to `dependencies` (always-on) or to `[project.optional-dependencies]` as its own extra (optional)
+   - add `ra-mcp-metadata-lib`/`ra-mcp-metadata-mcp` under `[tool.uv.sources]` and `known-first-party`
+4. Register in [server.py](src/ra_mcp_server/server.py) `AVAILABLE_MODULES`.
 
-```python
-from metadata_mcp.tools import metadata_mcp
+   **Always-on modules** (search, browse, guide, htr, viewer, pdf) are imported eagerly at the top of
+   the file and added to the `AVAILABLE_MODULES` dict literal:
 
-AVAILABLE_MODULES = {
-    ...
-    "metadata": {
-        "server": metadata_mcp,
-        "description": "Advanced metadata search and filtering",
-        "default": False,
-    },
-}
-```
+   ```python
+   from ra_mcp_metadata_mcp import metadata_mcp
 
-5. Add dependencies to root `pyproject.toml`
+   AVAILABLE_MODULES = {
+       ...
+       "metadata": {
+           "server": metadata_mcp,
+           "description": "Advanced metadata search and filtering",
+           "default": True,
+       },
+   }
+   ```
+
+   **Optional modules** (label + the LanceDB datasets) follow the guarded `try`/`import` pattern so a
+   missing optional dependency just skips the module instead of breaking startup:
+
+   ```python
+   try:
+       from ra_mcp_metadata_mcp import metadata_mcp  # ty: ignore[unresolved-import]
+
+       AVAILABLE_MODULES["metadata"] = {
+           "server": metadata_mcp,
+           "description": "Advanced metadata search and filtering",
+           "default": True,
+       }
+   except ImportError:
+       pass
+   ```
+
+   Optional notes: set `"no_namespace": True` to mount the module's tools without a namespace prefix
+   (as viewer/pdf/sbl do).
+
+5. Optionally add a CLI/TUI front-end and wire it into the relevant extra.
+
+The server currently registers 21 modules: 6 always-on (search, browse, guide, htr, viewer, pdf) plus
+15 optional (label, diplomatics, sbl, sjomanshus, filmcensur, rosenberg, court, aktiebolag, faltjagare,
+suffrage, specialsok, dds, wincars, sj, tora).
 
 ### Adding API Clients
 
-1. Create new client in the appropriate domain package (e.g., [packages/browse/src/ra_mcp_browse/clients/](packages/browse/src/ra_mcp_browse/clients/))
-2. Follow existing patterns (see [alto_client.py](packages/browse/src/ra_mcp_browse/clients/alto_client.py))
+1. Create a new client lib package (the ALTO/IIIF/OAI-PMH clients each live in their own `*-lib` package)
+2. Follow existing patterns (see [client.py](packages/xml-lib/src/ra_mcp_xml/client.py) for `ALTOClient`, or [iiif-lib](packages/iiif-lib/src/ra_mcp_iiif_lib/client.py) / [oai-pmh-lib](packages/oai-pmh-lib/src/ra_mcp_oai_pmh_lib/client.py))
 3. Use the centralized HTTPClient from `ra_mcp_common`
 4. Add comprehensive error handling
 5. Use dependency injection for HTTP client
@@ -776,7 +850,7 @@ tools/call search_transcribed          ← FastMCP (automatic)
 └── delegate search_transcribed        ← FastMCP (composed server)
     └── tools/call search_transcribed  ← FastMCP (local provider)
         └── SearchOperations.search    ← manual span
-            └── SearchAPI.search       ← manual span
+            └── SearchClient.search    ← manual span
                 └── HTTP GET           ← manual span
 ```
 
@@ -795,7 +869,7 @@ RA_MCP_OTEL_LOG_BRIDGE=true           # Bridge Python logging to OTel (default: 
 | Component | Tracer name | Spans | Metrics |
 |-----------|-------------|-------|---------|
 | HTTP client | `ra_mcp.http_client` | `HTTP GET` | request count, error count, duration, response size |
-| Search API | `ra_mcp.search_api` | `SearchAPI.search` | — |
+| Search client | `ra_mcp.search.client` | `SearchClient.search` | — |
 | Search ops | `ra_mcp.search_operations` | `SearchOperations.search` | — |
 | Browse ops | `ra_mcp.browse_operations` | `browse_document`, `_fetch_page_contexts` | — |
 | ALTO client | `ra_mcp.alto_client` | `ALTOClient.fetch_content` | — |
@@ -874,7 +948,7 @@ When working with this codebase:
 2. **Read full context**: Use the Read tool on complete files, not just snippets
 3. **Prefer modifications**: Edit existing code rather than creating new files
 4. **Check types**: The project uses type hints - maintain them in all code
-5. **Follow patterns**: Match existing code style and patterns (see [packages/search/src/ra_mcp_search/operations/](packages/search/src/ra_mcp_search/operations/))
+5. **Follow patterns**: Match existing code style and patterns (see [packages/search-lib/src/ra_mcp_search_lib/](packages/search-lib/src/ra_mcp_search_lib/))
 6. **Document thoroughly**: MCP tools need excellent documentation for LLM understanding
-7. **Workspace awareness**: Changes to common affect all packages; changes to search affect search-mcp and search-cli
-8. **Layered architecture**: Domain logic lives in search/browse packages; MCP wrappers in *-mcp packages; CLI in *-cli packages
+7. **Workspace awareness**: Changes to common affect all packages; changes to search-lib affect search-mcp, search-cli, and the TUI
+8. **Layered architecture**: Domain logic lives in `*-lib` packages; MCP wrappers in `*-mcp` packages; CLI in `*-cli` packages and the TUI in `tui`

--- a/README.md
+++ b/README.md
@@ -51,8 +51,10 @@ claude mcp add --transport http ra-mcp https://riksarkivet-ra-mcp.hf.space/mcp
 
 ## Quick Start (CLI)
 
+The `ra` command imports the search, browse, and TUI sub-apps unconditionally, so install the `cli` and `tui` extras to get a working CLI:
+
 ```bash
-uv pip install ra-mcp
+uv pip install "ra-mcp[cli,tui]"
 ```
 
 ```bash

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -7,6 +7,16 @@ Auto-generated reference documentation for all public Python APIs in the ra-mcp 
 | Package | Description |
 |---------|-------------|
 | [Common](common.md) | Shared HTTP client and utility functions |
-| [Search](search.md) | Search domain — models, client, and operations |
-| [Browse](browse.md) | Browse domain — models, clients, and operations |
-| [MCP Tools](mcp-tools.md) | MCP tool and resource registrations (search, browse, guide, HTR, viewer) |
+| [Search](search.md) | Search domain (`ra-mcp-search-lib`) — models, client, and operations |
+| [Browse](browse.md) | Browse domain (`ra-mcp-browse-lib`) — models, operations, URL generation |
+| [MCP Tools](mcp-tools.md) | MCP tool and resource registrations (search, browse, guide, HTR, viewer, PDF, Label Studio, datasets) |
+
+The ALTO, IIIF, and OAI-PMH HTTP clients that browse depends on now live in their own
+libraries — **`ra-mcp-xml`** (`ra_mcp_xml`), **`ra-mcp-iiif-lib`** (`ra_mcp_iiif_lib`), and
+**`ra-mcp-oai-pmh-lib`** (`ra_mcp_oai_pmh_lib`).
+
+The optional dataset modules (e.g. `ra-mcp-court-mcp`, `ra-mcp-dds-mcp`, `ra-mcp-sbl-mcp`), the
+PDF viewer (`ra-mcp-pdf-mcp`), and the Label Studio importer (`ra-mcp-label-mcp`) each expose their
+own MCP tools. They are described on the [MCP Tools](mcp-tools.md) page and in the
+[Tools reference](../tools/tools.md); their auto-generated API is omitted here because they are
+optional and not all are installed in every deployment.

--- a/docs/api/mcp-tools.md
+++ b/docs/api/mcp-tools.md
@@ -29,3 +29,27 @@ MCP tool and resource registrations exposed by the ra-mcp server.
 ## Viewer Tools
 
 ::: ra_mcp_viewer_mcp.tools
+
+## PDF Tools
+
+Provided by `ra-mcp-pdf-mcp` (module `ra_mcp_pdf_mcp.tools`). Registers an MCP App PDF
+viewer plus `display_pdf`, `search_pdf`, `list_pdfs`, `read_pdf_page`, and the app-control
+tools (`pdf_go_to_page`, `pdf_set_search`, `get_pdf_state`, `get_page_blocks`,
+`read_pdf_bytes`, `search_guides`). See the [Tools reference](../tools/tools.md#display_pdf)
+for parameters. Auto-generated docs are omitted here because the package is outside the API
+autodoc paths.
+
+## Label Studio Tools
+
+Provided by the optional `ra-mcp-label-mcp` (module `ra_mcp_label_mcp.tools`). Registers
+`import_to_label_studio`, which imports document pages and ALTO transcriptions into a Label
+Studio project for human annotation.
+
+## Dataset Tools
+
+The optional dataset modules each register namespaced search tools over local LanceDB tables:
+`diplomatics`, `sbl`, `sjomanshus`, `filmcensur`, `rosenberg`, `court`, `aktiebolag`,
+`faltjagare`, `suffrage`, `specialsok`, `dds`, `wincars`, `sj`, and `tora`. The full tool list
+and coverage figures are in the [Tools reference](../tools/tools.md#dataset-tools) and
+[Data Sources](../how-it-works/data-sources.md#local-lancedb-datasets). Auto-generated API docs
+are omitted here because these packages are optional and outside the autodoc paths.

--- a/docs/development/index.md
+++ b/docs/development/index.md
@@ -20,18 +20,30 @@ Requires Python 3.13+ and [uv](https://docs.astral.sh/uv/).
 
 ## Running the Server
 
+The viewer and PDF modules ship Svelte UIs that must be built into single HTML files before
+serving. Run `make build-ui` once (and after any UI change) before `ra serve`; the `make serve`
+and `make serve-http` targets do this for you.
+
 ```bash
-# MCP server (stdio) — for Claude Desktop integration
+# Build the viewer + PDF MCP App UIs (Svelte → HTML)
+make build-ui
+
+# MCP server (stdio, the default) — for Claude Desktop integration
 uv run ra serve
 
-# MCP server (HTTP) — for web clients, testing, and development
+# MCP server (HTTP) — passing --port switches to HTTP/SSE transport
 uv run ra serve --port 7860
 
 # With verbose logging
 uv run ra serve --port 7860 -v
 
-# Selective modules
+# Selective modules / list modules
 uv run ra serve --port 7860 --modules search,browse
+uv run ra serve --list-modules
+
+# Or use the Makefile (runs build-ui first)
+make serve        # stdio
+make serve-http   # HTTP on port 7860
 ```
 
 ## Testing with MCP Inspector
@@ -47,12 +59,11 @@ npx @modelcontextprotocol/inspector uv run ra serve
 uv run pytest
 
 # Run specific package tests
-uv run pytest packages/common/tests/ -v
-uv run pytest packages/search/tests/ -v
-uv run pytest packages/browse/tests/ -v
+uv run pytest packages/search-lib/tests/ -v
+uv run pytest packages/browse-lib/tests/ -v
 
 # Run with coverage
-uv run pytest --cov=ra_mcp_common --cov=ra_mcp_search --cov=ra_mcp_browse --cov-report=html
+uv run pytest --cov=ra_mcp_common --cov=ra_mcp_search_lib --cov=ra_mcp_browse_lib --cov-report=html
 ```
 
 ### Testing Principles
@@ -117,9 +128,9 @@ Always run `dagger call checks` before committing.
 
 ## Adding a New Module
 
-1. Create domain package: `packages/mymodule/` with models, clients, operations
+1. Create domain library: `packages/mymodule-lib/` with models, clients, operations
 2. Create MCP package: `packages/mymodule-mcp/` with tool registration
-3. Register in `src/ra_mcp_server/server.py` `AVAILABLE_MODULES`:
+3. Register in `src/ra_mcp_server/server.py` `AVAILABLE_MODULES` (wrap optional/heavy-dependency modules in `try/except ImportError`, and set `no_namespace=True` to expose tools without a module prefix):
 
 ```python
 AVAILABLE_MODULES = {

--- a/docs/development/observability.md
+++ b/docs/development/observability.md
@@ -24,7 +24,7 @@ graph TD
   B["delegate search_transcribed\n<i>FastMCP — composed server</i>"]
   C["tools/call search_transcribed\n<i>FastMCP — provider</i>"]
   D["SearchOperations.search\n<i>domain layer</i>"]
-  E["SearchAPI.search\n<i>API client</i>"]
+  E["SearchClient.search\n<i>API client</i>"]
   F["HTTP GET\n<i>HTTP client</i>"]
 
   A --> B --> C --> D --> E --> F
@@ -35,7 +35,7 @@ graph TD
 | Component | Tracer name | Spans | Metrics |
 |-----------|-------------|-------|---------|
 | HTTP client | `ra_mcp.http_client` | `HTTP GET` | request count, error count, duration, response size |
-| Search API | `ra_mcp.search_api` | `SearchAPI.search` | — |
+| Search client | `ra_mcp.search.client` | `SearchClient.search` | — |
 | Search ops | `ra_mcp.search_operations` | `SearchOperations.search` | — |
 | Browse ops | `ra_mcp.browse_operations` | `browse_document`, `_fetch_page_contexts` | — |
 | ALTO client | `ra_mcp.alto_client` | `ALTOClient.fetch_content` | — |

--- a/docs/getting-started/local.md
+++ b/docs/getting-started/local.md
@@ -6,8 +6,10 @@ If you want to search and browse directly from your terminal (no AI client neede
 
 ## Install the CLI
 
+The `ra` command imports the search, browse, and TUI sub-apps unconditionally, so install the `cli` and `tui` extras for a working CLI:
+
 ```bash
-uv pip install ra-mcp
+uv pip install "ra-mcp[cli,tui]"
 ```
 
 ```bash
@@ -21,10 +23,10 @@ ra browse "SE/RA/310187/1" --pages "7,8,52" --search-term "trolldom"
 
 ## Interactive TUI
 
-For a full terminal browser experience:
+The TUI ships in the `tui` extra (already included above). If you only want the terminal browser:
 
 ```bash
-uv pip install "ra-mcp[tui]"
+uv pip install "ra-mcp[cli,tui]"
 ```
 
 ```bash
@@ -45,6 +47,9 @@ For development or private deployments:
 git clone https://github.com/AI-Riksarkivet/ra-mcp.git
 cd ra-mcp
 uv sync
+
+# Build the viewer-mcp and pdf-mcp App UIs (required before serving, or the MCP App UIs won't be built)
+make build-ui
 
 # Run MCP server on HTTP
 uv run ra serve --port 7860

--- a/docs/how-it-works/architecture.md
+++ b/docs/how-it-works/architecture.md
@@ -1,24 +1,66 @@
 # Architecture
 
-ra-mcp is organized as a **uv workspace** with modular packages, each with a single responsibility.
+ra-mcp is organized as a **uv workspace** with 44 packages under `packages/` plus a root server, each with a single responsibility. Packages follow a naming convention by role:
+
+- `*-lib` — domain libraries (Pydantic models, API clients, operations), plus `common`
+- `*-mcp` — FastMCP servers that wrap a domain library as MCP tools/resources
+- `search-cli` / `browse-cli` / `tui` — CLI and terminal-UI front-ends
 
 ---
 
 ## Package Overview
 
+### Foundation & domain libraries (Layer 0–1)
+
 | Package | Layer | Purpose |
 |---------|-------|---------|
-| **ra-mcp-common** | 0 | Shared HTTP client, telemetry helpers, formatting utilities |
-| **ra-mcp-search** | 1 | Search domain: Pydantic models, API client, operations |
-| **ra-mcp-browse** | 1 | Browse domain: models, ALTO/IIIF/OAI-PMH clients, operations |
+| **ra-mcp-common** | 0 | Shared HTTP client, telemetry helpers, formatting, dataset utilities |
+| **ra-mcp-xml** | 1 | `ALTOClient` — ALTO XML parsing (extracted from browse) |
+| **ra-mcp-iiif-lib** | 1 | `IIIFClient` — IIIF collections & manifests (extracted from browse) |
+| **ra-mcp-oai-pmh-lib** | 1 | `OAIPMHClient` — OAI-PMH metadata (extracted from browse) |
+| **ra-mcp-search-lib** | 1 | Search domain: Pydantic models, API client, operations |
+| **ra-mcp-browse-lib** | 1 | Browse domain: models, operations, URL generation |
+
+### Core MCP & front-end packages (Layer 2)
+
+| Package | Layer | Purpose |
+|---------|-------|---------|
 | **ra-mcp-search-mcp** | 2 | MCP tools: `search_transcribed`, `search_metadata` |
 | **ra-mcp-browse-mcp** | 2 | MCP tool: `browse_document` |
-| **ra-mcp-guide-mcp** | 2 | MCP resources: archival research guides (50+ sections) |
+| **ra-mcp-guide-mcp** | 2 | MCP resources: archival research guides |
 | **ra-mcp-htr-mcp** | 2 | MCP tool: `htr_transcribe` (handwritten text recognition) |
 | **ra-mcp-viewer-mcp** | 2 | MCP App: interactive document viewer with zoomable images |
+| **ra-mcp-pdf-mcp** | 2 | MCP App: interactive PDF viewer (PDF.js, search, annotations) |
+| **ra-mcp-label-mcp** | 2 | MCP tool: import pages to Label Studio for human annotation (optional) |
 | **ra-mcp-search-cli** | 2 | CLI command: `ra search` |
 | **ra-mcp-browse-cli** | 2 | CLI command: `ra browse` |
 | **ra-mcp-tui** | 2 | Interactive terminal browser: `ra tui` |
+
+### Dataset packages (Layer 1–2, optional)
+
+Each dataset ships as a `*-lib` (LanceDB-backed query layer) plus a `*-mcp` (MCP tools). All are optional — they load only when `lancedb` is installed.
+
+| Package pair | Dataset / tools |
+|--------------|-----------------|
+| **diplomatics-lib / -mcp** | SDHK medieval charters + MPO parchment fragments |
+| **sbl-lib / -mcp** | Svenskt biografiskt lexikon (biographical articles) |
+| **sjomanshus-lib / -mcp** | Seamen's house records (voyages, registrations) |
+| **filmcensur-lib / -mcp** | Film censorship records 1911–2011 |
+| **rosenberg-lib / -mcp** | Rosenberg's geographical lexicon |
+| **court-lib / -mcp** | Court records (Domboksregister, Medelstad) |
+| **aktiebolag-lib / -mcp** | Joint-stock company records |
+| **faltjagare-lib / -mcp** | Jämtland field regiment soldiers |
+| **suffrage-lib / -mcp** | Women's suffrage records |
+| **specialsok-lib / -mcp** | Specialsök datasets (flygvapen, fångrullor, kurhuset, press, video) |
+| **dds-lib / -mcp** | Church records (births, deaths, marriages) |
+| **wincars-lib / -mcp** | Norrland vehicle registrations |
+| **sj-lib / -mcp** | SJ railway properties & technical drawings |
+| **tora-lib / -mcp** | TORA historical-place geocoding |
+
+### Composition & plugin
+
+| Package | Layer | Purpose |
+|---------|-------|---------|
 | **ra-mcp** (root) | 3 | Server composition + Typer CLI entry point |
 | **ra-mcp-tools** (plugin) | — | Claude Code skills for research workflows |
 
@@ -28,35 +70,43 @@ ra-mcp is organized as a **uv workspace** with modular packages, each with a sin
 graph TD
   common["ra-mcp-common\nshared HTTP client, telemetry"]
 
-  search["ra-mcp-search\nsearch domain"]
-  browse["ra-mcp-browse\nbrowse domain"]
+  clients["xml / iiif-lib / oai-pmh-lib\nALTO, IIIF, OAI-PMH clients"]
+  search["ra-mcp-search-lib\nsearch domain"]
+  browse["ra-mcp-browse-lib\nbrowse domain"]
+  datasets["*-lib\n14 LanceDB dataset libraries"]
 
-  search_mcp["ra-mcp-search-mcp\nMCP tools"]
-  search_cli["ra-mcp-search-cli\nCLI command"]
-  browse_mcp["ra-mcp-browse-mcp\nMCP tool"]
-  browse_cli["ra-mcp-browse-cli\nCLI command"]
-  guide["ra-mcp-guide-mcp\nMCP resources"]
-  htr["ra-mcp-htr-mcp\nHTR tool"]
+  search_mcp["ra-mcp-search-mcp"]
+  browse_mcp["ra-mcp-browse-mcp"]
+  guide["ra-mcp-guide-mcp"]
+  htr["ra-mcp-htr-mcp"]
   viewer["ra-mcp-viewer-mcp\nMCP App"]
-  tui["ra-mcp-tui\nTerminal UI"]
+  pdf["ra-mcp-pdf-mcp\nMCP App"]
+  dataset_mcp["*-mcp\ndataset MCP servers"]
+  cli["search-cli / browse-cli / tui"]
 
-  root["ra-mcp (root)\ncomposes all packages"]
+  root["ra-mcp (root)\ncomposes all MCP packages"]
 
-  common --> search & browse & guide
-  search --> search_mcp & search_cli & tui
-  browse --> browse_mcp & browse_cli & tui
-  search_mcp & search_cli & browse_mcp & browse_cli & guide & htr & viewer & tui --> root
+  common --> clients & search & browse & datasets & guide
+  clients --> browse
+  search --> search_mcp & cli
+  browse --> browse_mcp & cli
+  datasets --> dataset_mcp
+  search_mcp & browse_mcp & guide & htr & viewer & pdf & dataset_mcp & cli --> root
 ```
 
 ## Layer Architecture
 
 **Layer 0 — Foundation**
 
-`ra-mcp-common` has no internal dependencies. It provides the `HTTPClient` (with retry, telemetry, and logging) used by all other packages.
+`ra-mcp-common` has no internal dependencies. It provides the `HTTPClient` (with retry, telemetry, and logging) plus shared formatting and dataset utilities used by all other packages.
 
 **Layer 1 — Domain**
 
-`ra-mcp-search` and `ra-mcp-browse` contain pure business logic: Pydantic models, API clients, and operations. No MCP or CLI dependency — they can be used as standalone Python libraries.
+The domain libraries contain pure business logic — Pydantic models, API clients, and operations — with no MCP or CLI dependency, so they can be used as standalone Python libraries:
+
+- `ra-mcp-search-lib` and `ra-mcp-browse-lib` cover full-text search and page browsing.
+- The HTTP clients that used to live inside browse are now their own packages: **`ra-mcp-xml`** (`ALTOClient`), **`ra-mcp-iiif-lib`** (`IIIFClient`), and **`ra-mcp-oai-pmh-lib`** (`OAIPMHClient`). `browse-lib` depends on them.
+- Each dataset has a `*-lib` package that queries a local LanceDB table.
 
 **Layer 2 — Interface**
 
@@ -66,29 +116,52 @@ Thin wrappers that expose domain logic through different interfaces:
 - **CLI packages** (`*-cli`) register Typer commands with Rich output
 - **TUI** (`ra-mcp-tui`) provides an interactive Textual application
 - **HTR** (`ra-mcp-htr-mcp`) delegates to a remote Gradio Space
-- **Viewer** (`ra-mcp-viewer-mcp`) is an MCP App serving an interactive HTML viewer
+- **Viewer** (`ra-mcp-viewer-mcp`) and **PDF** (`ra-mcp-pdf-mcp`) are MCP Apps serving interactive HTML UIs
 
 **Layer 3 — Composition**
 
-The root package composes all MCP sub-servers into a single server using `FastMCP.add_provider()`. Each module gets a namespace (e.g., `search.transcribed`, `browse.document`) except the viewer which registers at root level.
+The root package composes all enabled MCP sub-servers into a single server using `FastMCP.add_provider()`. Each module gets a namespace derived from the module name (e.g. tool `search_domboksregister` in the `court` module is exposed as `court:search_domboksregister`), except modules flagged `no_namespace` — currently **viewer**, **pdf**, and **sbl** — which register their tools at root level.
 
 ## Module System
 
-The root server has a registry of available modules:
+The root server has a registry of available modules (`AVAILABLE_MODULES` in `src/ra_mcp_server/server.py`). All 21 modules are enabled by default. The optional dataset/annotation modules are wrapped in `try/except ImportError`, so they only register when their dependencies (e.g. `lancedb`, `label-studio-sdk`) are installed.
 
-| Module | Default | Tools / Resources |
-|--------|---------|-------------------|
-| `search` | Enabled | `search_transcribed`, `search_metadata` |
-| `browse` | Enabled | `browse_document` |
-| `guide` | Enabled | Historical research guides (MCP resources) |
-| `htr` | Enabled | `htr_transcribe` |
-| `viewer` | Enabled | `view_document`, `load_page`, `load_thumbnails` |
+**Always-on core modules**
+
+| Module | Namespaced | Tools / Resources |
+|--------|------------|-------------------|
+| `search` | `search:` | `search_transcribed`, `search_metadata` |
+| `browse` | `browse:` | `browse_document` |
+| `guide` | `guide:` | Historical research guides (MCP resources) |
+| `htr` | `htr:` | `htr_transcribe` |
+| `viewer` | root (no namespace) | `view_document`, `view_manifest`, `view_bild`, `load_page`, `load_thumbnails`, plus viewer-app controls |
+| `pdf` | root (no namespace) | `display_pdf`, `search_pdf`, `list_pdfs`, `read_pdf_page`, plus pdf-app controls |
+
+**Optional modules** (load when dependencies are present)
+
+| Module | Namespaced | Tools |
+|--------|------------|-------|
+| `label` | `label:` | `import_to_label_studio` |
+| `diplomatics` | `diplomatics:` | `search_sdhk`, `search_mpo`, `view_sdhk`, `view_mpo` |
+| `sbl` | root (no namespace) | `search_sbl`, `view_sbl_article`, `load_sbl_article` |
+| `sjomanshus` | `sjomanshus:` | `search_liggare`, `search_matrikel` |
+| `filmcensur` | `filmcensur:` | `search_filmreg` |
+| `rosenberg` | `rosenberg:` | `search_rosenberg` |
+| `court` | `court:` | `search_domboksregister`, `search_medelstad` |
+| `aktiebolag` | `aktiebolag:` | `search_bolag`, `search_styrelse` |
+| `faltjagare` | `faltjagare:` | `search_faltjagare` |
+| `suffrage` | `suffrage:` | `search_rostratt`, `search_fkpr` |
+| `specialsok` | `specialsok:` | `search_flygvapen`, `search_fangrullor`, `search_kurhuset`, `search_press`, `search_video` |
+| `dds` | `dds:` | `search_fodelse`, `search_doda`, `search_vigsel` |
+| `wincars` | `wincars:` | `search_wincars` |
+| `sj` | `sj:` | `search_juda`, `search_ritningar` |
+| `tora` | `tora:` | `search_tora` |
 
 Modules can be selectively enabled:
 
 ```bash
 ra serve --modules search,browse     # Only search and browse
-ra serve --list-modules              # Show available modules
+ra serve --list-modules              # Show available modules and exit
 ```
 
 ## Plugin System
@@ -100,20 +173,31 @@ The server discovers skills from `plugins/*/skills/` directories at startup usin
 ```
 ra-mcp/
 ├── src/ra_mcp_server/          # Root: Server composition, CLI, telemetry
-├── packages/
-│   ├── common/                 # Layer 0: HTTPClient, telemetry, formatting
-│   ├── search/                 # Layer 1: Search domain
-│   ├── browse/                 # Layer 1: Browse domain
-│   ├── search-mcp/            # Layer 2: MCP tools for search
-│   ├── browse-mcp/            # Layer 2: MCP tool for browse
-│   ├── guide-mcp/             # Layer 2: MCP resources for guides
-│   ├── htr-mcp/               # Layer 2: MCP tool for HTR
-│   ├── viewer-mcp/            # Layer 2: MCP App for document viewing
-│   ├── search-cli/            # Layer 2: CLI for search
-│   ├── browse-cli/            # Layer 2: CLI for browse
-│   └── tui/                   # Layer 2: Terminal UI
+│   └── server.py               # FastMCP composition + AVAILABLE_MODULES registry
+├── packages/                   # 44 workspace packages
+│   ├── common/                 # Layer 0: HTTPClient, telemetry, formatting, datasets
+│   ├── xml-lib/                # Layer 1: ALTOClient (ALTO XML)
+│   ├── iiif-lib/               # Layer 1: IIIFClient
+│   ├── oai-pmh-lib/            # Layer 1: OAIPMHClient
+│   ├── search-lib/             # Layer 1: Search domain
+│   ├── browse-lib/             # Layer 1: Browse domain (depends on xml/iiif/oai)
+│   ├── search-mcp/             # Layer 2: MCP tools for search
+│   ├── browse-mcp/             # Layer 2: MCP tool for browse
+│   ├── guide-mcp/              # Layer 2: MCP resources for guides
+│   ├── htr-mcp/                # Layer 2: MCP tool for HTR
+│   ├── viewer-mcp/             # Layer 2: MCP App for document viewing
+│   ├── pdf-mcp/                # Layer 2: MCP App for PDF viewing
+│   ├── label-mcp/              # Layer 2: Label Studio import (optional)
+│   ├── search-cli/             # Layer 2: CLI for search
+│   ├── browse-cli/             # Layer 2: CLI for browse
+│   ├── tui/                    # Layer 2: Terminal UI
+│   └── <dataset>-lib/-mcp/     # 14 optional dataset modules (diplomatics, sbl,
+│                               #   sjomanshus, filmcensur, rosenberg, court,
+│                               #   aktiebolag, faltjagare, suffrage, specialsok,
+│                               #   dds, wincars, sj, tora)
 ├── plugins/
-│   └── ra-mcp-tools/          # Claude Code skills plugin
+│   └── ra-mcp-tools/          # Claude Code skills plugin (8 skills)
+├── resources/                  # Historical guide markdown files
 ├── docs/                       # Documentation site (Zensical)
 ├── charts/ra-mcp/             # Helm chart
 ├── pyproject.toml             # Workspace root

--- a/docs/how-it-works/data-sources.md
+++ b/docs/how-it-works/data-sources.md
@@ -1,6 +1,10 @@
 # Data Sources & Coverage
 
-ra-mcp connects to several Riksarkivet APIs:
+ra-mcp draws on two kinds of data sources: **live Riksarkivet HTTP APIs** (the core search/browse/viewer tools) and **local LanceDB datasets** that ship with the optional dataset modules.
+
+## Live HTTP APIs
+
+The core modules connect to several Riksarkivet APIs:
 
 | API | Endpoint | Purpose |
 |-----|----------|---------|
@@ -10,9 +14,32 @@ ra-mcp connects to several Riksarkivet APIs:
 | **OAI-PMH** | `oai-pmh.riksarkivet.se/OAI` | Document metadata and collection structure |
 | **Bildvisaren** | `sok.riksarkivet.se/bildvisning` | Interactive image viewer (links provided in results) |
 
-All data comes from the [Riksarkivet Data Platform](https://github.com/Riksarkivet/dataplattform/wiki), which hosts AI-transcribed materials from the Swedish National Archives.
+Most of this data comes from the [Riksarkivet Data Platform](https://github.com/Riksarkivet/dataplattform/wiki), which hosts AI-transcribed materials from the Swedish National Archives. HTR re-transcription is delegated to the [HTRflow](https://pypi.org/project/htrflow/) Gradio Space.
 
-Additional resources: [Förvaltningshistorik](https://forvaltningshistorik.riksarkivet.se/Index.htm) (semantic search, experimental), [HTRflow](https://pypi.org/project/htrflow/) (handwritten text recognition).
+Additional resources: [Förvaltningshistorik](https://forvaltningshistorik.riksarkivet.se/Index.htm) (semantic search, experimental).
+
+## Local LanceDB datasets
+
+The optional dataset modules query **local LanceDB tables** rather than a live API — they are full-text/vector indexes bundled with the dataset packages. They load only when `lancedb` is installed, and each adds its own namespaced search tools (see [Module System](architecture.md#module-system)). Scale figures below are reported by the modules themselves.
+
+| Dataset (module) | Coverage | Tools |
+|------------------|----------|-------|
+| **SDHK + MPO** (`diplomatics`) | 44,000+ medieval charters; 23,000+ parchment fragments | `search_sdhk`, `search_mpo`, `view_sdhk`, `view_mpo` |
+| **SBL** (`sbl`) | 9,400+ biographical articles (Svenskt biografiskt lexikon) | `search_sbl`, `view_sbl_article`, `load_sbl_article` |
+| **Sjömanshus** (`sjomanshus`) | 688,000+ seamen's records (voyages, registrations), 1700s–1900s | `search_liggare`, `search_matrikel` |
+| **Filmcensur** (`filmcensur`) | 60,000 film censorship records, 1911–2011 | `search_filmreg` |
+| **Rosenberg** (`rosenberg`) | 66,000 historical places (geographical lexicon) | `search_rosenberg` |
+| **Court records** (`court`) | Domboksregister (Västra härad 1611–1730), Medelstad (1668–1750) | `search_domboksregister`, `search_medelstad` |
+| **Aktiebolag** (`aktiebolag`) | Joint-stock companies 1901–1935 (~12.5K companies, ~49K board members) | `search_bolag`, `search_styrelse` |
+| **Fältjägare** (`faltjagare`) | Jämtland field regiment soldiers 1645–1901 (~43K) | `search_faltjagare` |
+| **Suffrage** (`suffrage`) | Women's suffrage records (Rösträtt petition 1913–1914, FKPR 1911–1920) | `search_rostratt`, `search_fkpr` |
+| **Specialsök** (`specialsok`) | Flygvapen, fångrullor, kurhuset, press, video datasets | `search_flygvapen`, `search_fangrullor`, `search_kurhuset`, `search_press`, `search_video` |
+| **DDS church records** (`dds`) | ~2.5M births, deaths, marriages (1600s–1900s) | `search_fodelse`, `search_doda`, `search_vigsel` |
+| **Wincars** (`wincars`) | Norrland vehicle registrations 1916–1972 (~1.5M across 5 counties) | `search_wincars` |
+| **SJ railway** (`sj`) | Properties (198K JUDA) and technical drawings (118K FIRA/SIRA) | `search_juda`, `search_ritningar` |
+| **TORA** (`tora`) | 51K settlements with coordinates (historical-place geocoding) | `search_tora` |
+
+In addition, the optional `label` module is not a dataset but an integration that imports pages to a Label Studio instance for human annotation (`import_to_label_studio`).
 
 ---
 
@@ -41,7 +68,7 @@ ra-mcp is one piece of a larger ecosystem. Multiple MCP servers can be connected
 ``` mermaid
 graph LR
   client["AI Client\n(Claude)"]
-  client --> ramcp["ra-mcp\nSearch, browse, HTR, viewer, guides"]
+  client --> ramcp["ra-mcp\nSearch, browse, HTR, viewer, PDF,\nguides, dataset modules"]
   client --> htrflow["htrflow-mcp\nStandalone HTR\n(alternative)"]
   client --> other["other servers\nAny MCP-compatible tool"]
 ```

--- a/docs/how-it-works/index.md
+++ b/docs/how-it-works/index.md
@@ -17,6 +17,7 @@ graph LR
   A["AI Client\n(Claude, ChatGPT, etc)"] <-->|"MCP\ntool calls"| B["ra-mcp Server"]
   B --> C["Riksarkivet\nData Platform\n(Search, IIIF, ALTO, OAI-PMH)"]
   B --> D["HTRflow\nGradio Space\n(Handwritten text recognition)"]
+  B --> E["Local LanceDB datasets\n(SBL, court, church records,\ngeo lexicon, …)"]
 ```
 
 When you ask Claude *"Find documents about trolldom"*, the AI:
@@ -61,7 +62,15 @@ Transcribes handwritten document images using AI-powered handwritten text recogn
 
 ### view_document
 
-Displays document pages in an interactive viewer with zoomable images and text layer overlays. The viewer runs directly inside the MCP host (Claude, ChatGPT) as an MCP App.
+Displays document pages in an interactive viewer with zoomable images and text layer overlays. The viewer runs directly inside the MCP host (Claude, ChatGPT) as an MCP App. Companion entry points `view_manifest` (IIIF manifest) and `view_bild` (bildvisning URL) open the same viewer from different references.
+
+### display_pdf
+
+Opens a PDF in an interactive PDF.js viewer (search, page navigation, annotations) as an MCP App. Paired tools `search_pdf`, `list_pdfs`, and `read_pdf_page` let the AI search and read the bundled Riksarkivet archival PDF guides.
+
+### Dataset tools
+
+When the optional dataset modules are installed, the server also exposes namespaced search tools over local datasets — for example `sbl:search_sbl` (biographical lexicon), `court:search_domboksregister` (court records), `dds:search_fodelse` (church birth records), and `rosenberg:search_rosenberg` (geographical lexicon). See [Data Sources](data-sources.md#local-lancedb-datasets) for the full list.
 
 See [Tools & Skills](../tools/index.md) for full parameter documentation.
 

--- a/docs/tools/skills.md
+++ b/docs/tools/skills.md
@@ -1,25 +1,37 @@
 # Skills
 
-Skills are loaded from the [ra-mcp-tools plugin](https://github.com/AI-Riksarkivet/ra-mcp/tree/main/plugins/ra-mcp-tools) and provide research methodology guidance. They are auto-discovered from `plugins/*/skills/` directories.
+Skills are loaded from the [ra-mcp-tools plugin](https://github.com/AI-Riksarkivet/ra-mcp/tree/main/plugins/ra-mcp-tools) and provide research methodology guidance. They are auto-discovered from `plugins/*/skills/` directories. There are eight skills.
 
 ---
 
 ## /archive-search
 
-Essential pre-search guide. Covers tool selection (`search_transcribed` vs `search_metadata`), Solr query syntax, wildcards, fuzzy matching for OCR/HTR errors, old Swedish spelling variants (präst/prest, silver/silfver), proximity search, Boolean operators, and pagination workflows.
+Essential pre-search guide — load before calling `search_transcribed` or `search_metadata`. Covers tool selection (`search_transcribed` vs `search_metadata`), search strategy, Solr query syntax, wildcards, fuzzy matching for OCR/HTR errors, old Swedish spelling variants (präst/prest, silver/silfver), proximity search, Boolean operators, and pagination workflows.
 
 ## /archive-research
 
-Research methodology guide. Covers research integrity rules (never fabricate data, always cite precisely), cross-tool research workflow (discover, examine, contextualize, synthesize), browsing strategy, result presentation with proper citations, and archive coverage awareness.
+Essential research guide — load before browsing, reading, or presenting archival documents. Covers research integrity rules (never fabricate data, always cite precisely), citing sources with reference codes, translating old Swedish, the cross-tool research workflow (search, browse, synthesize), browsing strategy, result presentation, and coverage awareness.
+
+## /archival-guide
+
+Archival record-type and administrative-history guide. Maps a research topic (court records, church records, folkbokföring, bouppteckning, dombok, husförhörslängd, mantalslängd, military, tax, and prison records) to the correct Förvaltningshistorik chapters, which are available as MCP resources. Use when figuring out what records exist, which archive holds them, or how the archival structure works.
 
 ## /htr-transcription
 
-HTR workflow guide. Covers the full pipeline: determine image source, batch images into a single `htr_transcribe` call, present results as an interactive artifact. Documents language options, layout modes, export formats, and custom HTRflow YAML pipelines.
+HTR workflow guide. Covers the full pipeline: determine the image source, batch images into a single `htr_transcribe` call, and present results as an interactive artifact. Documents language options, layout modes, export formats, and custom HTRflow YAML pipelines.
 
 ## /view-document-guide
 
-Document viewer guide. Covers the `view_document` tool's arguments, pairing rules, and common mistakes.
+Document viewer guide. Covers the viewer tools' arguments, pairing rules, and common mistakes across the reference-code, IIIF-manifest, and raw-URL entry points (`view_document`, `view_manifest`, `view_bild`).
+
+## /pdf-guide
+
+PDF guide for Riksarkivet's bundled archival PDFs (medieval Sweden, governance 1520–1920, Sami history). Use when the user asks about Swedish history, archives, medieval charters, governance, or Sami history, or wants to open/search the PDF guides. Provides section-level references with page numbers for citation.
 
 ## /upload-files
 
-File upload guide. Covers uploading local files or attachments to get public URLs for HTR or the viewer.
+File upload guide. Covers uploading local files or user attachments to the Gradio server to get back public URLs for HTR or the viewer.
+
+## /feedback-ls
+
+Label Studio feedback guide. Covers sending document pages (with ALTO transcriptions) to a Label Studio project for human review, transcription correction, and segmentation/quality feedback via the `import_to_label_studio` tool.

--- a/docs/tools/tools.md
+++ b/docs/tools/tools.md
@@ -91,3 +91,56 @@ Display document pages with zoomable images and text layer overlays in an intera
 | `metadata` | list[str] \| None | None | Per-page labels (reference codes, descriptions). |
 
 Both lists must have the same length.
+
+The viewer module also exposes two convenience entry points that open the same viewer from a different reference:
+
+- **view_manifest** — `manifest_url` (full IIIF manifest URL, e.g. SDHK/MPO results); optional `highlight_term`.
+- **view_bild** — `bild_ids` (one or more bildvisning image IDs, e.g. `C0056829_00001`).
+
+In addition the viewer registers app-control tools used by the running MCP App UI (`load_page`, `load_thumbnails`, `search_all_pages`, `viewer_navigate`, `viewer_go_to_page`, `viewer_set_highlight`, `viewer_reopen`, `get_viewer_state`).
+
+## display_pdf
+
+Open a PDF in an interactive PDF.js viewer (search, navigation, annotations) running as an MCP App.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `url` | str | *(bundled default)* | URL to a PDF file (direct links and academic sources supported). |
+| `title` | str \| None | None | Optional display title for the PDF. |
+
+Companion PDF tools:
+
+| Tool | Parameters | Purpose |
+|------|-----------|---------|
+| `search_pdf` | `url`, `term` | Find a term within a previously opened PDF. |
+| `read_pdf_page` | `url`, `page`, `count` (≤5) | Extract text from page(s) of a PDF. |
+| `list_pdfs` | — | List PDFs available in the gallery (bundled Riksarkivet guides). |
+
+The PDF module also registers app-control tools (`pdf_go_to_page`, `pdf_set_search`, `get_pdf_state`, `get_page_blocks`, `read_pdf_bytes`, `search_guides`).
+
+## Dataset tools
+
+When the optional dataset modules are installed, the server exposes namespaced search tools over local LanceDB datasets (see [Data Sources](../how-it-works/data-sources.md#local-lancedb-datasets) for coverage figures). Most follow a shared shape: a free-text `keyword`, `offset`/`limit` pagination, a `research_context`, and dataset-specific filters (e.g. `socken`/parish, `roll`/role, `datum_from`/`datum_till` date range on `court:search_domboksregister`).
+
+| Module | Tools |
+|--------|-------|
+| `diplomatics` | `search_sdhk`, `search_mpo`, `view_sdhk`, `view_mpo` |
+| `sbl` | `search_sbl`, `view_sbl_article`, `load_sbl_article` |
+| `sjomanshus` | `search_liggare`, `search_matrikel` |
+| `filmcensur` | `search_filmreg` |
+| `rosenberg` | `search_rosenberg` |
+| `court` | `search_domboksregister`, `search_medelstad` |
+| `aktiebolag` | `search_bolag`, `search_styrelse` |
+| `faltjagare` | `search_faltjagare` |
+| `suffrage` | `search_rostratt`, `search_fkpr` |
+| `specialsok` | `search_flygvapen`, `search_fangrullor`, `search_kurhuset`, `search_press`, `search_video` |
+| `dds` | `search_fodelse`, `search_doda`, `search_vigsel` |
+| `wincars` | `search_wincars` |
+| `sj` | `search_juda`, `search_ritningar` |
+| `tora` | `search_tora` |
+
+Note that `sbl` tools are exposed without a namespace prefix (e.g. `search_sbl`, not `sbl:search_sbl`); all other dataset tools are namespaced by module.
+
+## import_to_label_studio
+
+Imports document pages (images plus optional ALTO transcription) into a Label Studio project for human annotation and transcription feedback. Provided by the optional `label` module.

--- a/packages/aktiebolag-mcp/README.md
+++ b/packages/aktiebolag-mcp/README.md
@@ -1,0 +1,64 @@
+# ra-mcp-aktiebolag-mcp
+
+MCP tools for Swedish joint-stock company records (Aktiebolag 1901-1935) search.
+
+## Overview
+
+Thin MCP wrapper around `ra-mcp-aktiebolag-lib`. Registers two FastMCP tools — `search_bolag` and `search_styrelse` — backed by a lazily-opened LanceDB connection. The dataset covers Swedish joint-stock companies 1901-1935 (companies with >100,000 kr capital) and their board members. Both tools run full-text search over the LanceDB tables and return LLM-formatted plain text.
+
+Tools are registered as bare names (`search_bolag`, `search_styrelse`) and get namespaced as `aktiebolag:<tool>` when composed into the root server.
+
+## MCP Tools
+
+### `search_bolag`
+
+Search Swedish joint-stock companies 1901-1935 — 12,500 companies with >100,000 kr capital. Returns company name, purpose, address, board seat city, managing director, share capital, and board member names.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across company records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum records to return per query |
+| `styrelsesate` | str \| None | None | Optional filter: board seat city (case-insensitive substring match) |
+| `research_context` | str \| None | None | Brief summary of research goal (logging only) |
+
+### `search_styrelse`
+
+Search board members of Swedish companies 1901-1935 — 49,000 board members. Returns member name, title, gender, and company name.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across board member records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum records to return per query |
+| `titel` | str \| None | None | Optional filter: title (case-insensitive substring match) |
+| `research_context` | str \| None | None | Brief summary of research goal (logging only) |
+
+## Components
+
+- **tools.py**: FastMCP server (`aktiebolag_mcp`) setup, instructions, and tool registration
+- **bolag_tool.py**: `search_bolag` tool registration and LanceDB connection handling
+- **styrelse_tool.py**: `search_styrelse` tool registration and LanceDB connection handling
+- **formatter.py**: Formats company and board-member results for LLM consumption
+- **server.py**: Standalone entry point for isolated dev/testing
+
+## Standalone Usage
+
+```bash
+# HTTP transport (default, streamable-http on /mcp)
+python -m ra_mcp_aktiebolag_mcp.server --port 3009
+
+# stdio transport
+python -m ra_mcp_aktiebolag_mcp.server --stdio
+```
+
+The default port is `3009` (overridable via the `PORT` environment variable or `--port`).
+
+## Dependencies
+
+- Internal: `ra-mcp-aktiebolag-lib`
+- External: `fastmcp==3.1.1`
+
+## Part of ra-mcp
+
+Tools are registered as bare names and get namespaced as `aktiebolag:<tool>` when composed into the root server via the `AVAILABLE_MODULES` registry. See the [docs site](https://ai-riksarkivet.github.io/ra-mcp/) for full project documentation.

--- a/packages/browse-cli/README.md
+++ b/packages/browse-cli/README.md
@@ -26,7 +26,7 @@ The `--pages` / `--page` flags accept three formats:
 | Range | `"1-10"` | Pages 1 through 10 |
 | List | `"5,7,9"` | Specific pages |
 
-`--page` and `--pages` are interchangeable aliases.
+`--page` and `--pages` accept the same formats. If both are provided, `--page` takes precedence. If neither is given, the default is `1-20`.
 
 ## Flags
 
@@ -46,7 +46,7 @@ The `--pages` / `--page` flags accept three formats:
 
 ## Dependencies
 
-- Internal: `ra-mcp-browse`
+- Internal: `ra-mcp-browse-lib`
 - External: `typer`, `rich`
 
 ## Part of ra-mcp

--- a/packages/browse-lib/README.md
+++ b/packages/browse-lib/README.md
@@ -1,20 +1,24 @@
-# ra-mcp-browse
+# ra-mcp-browse-lib
 
 Browse domain package for Riksarkivet document pages.
 
 ## Overview
 
-Contains the business logic for browsing and retrieving document page transcriptions. This is a pure domain package — no MCP or CLI dependency. It orchestrates three different API clients (ALTO, IIIF, OAI-PMH) to assemble full page views with transcribed text, image links, and metadata.
+Contains the business logic for browsing and retrieving document page transcriptions. This is a pure domain package — no MCP or CLI dependency. It orchestrates three API clients — `ALTOClient`, `IIIFClient`, and `OAIPMHClient` — to assemble full page views with transcribed text, image links, and metadata. Those clients now live in their own workspace packages (`ra-mcp-xml`, `ra-mcp-iiif-lib`, `ra-mcp-oai-pmh-lib`) and are re-exported here for convenience.
 
 ## Components
 
-- **models.py**: Pydantic models — `BrowseResult` (full document browse result), `PageContext` (single page with transcription, image URL, ALTO URL), `OAIPMHMetadata` (document-level metadata)
-- **clients/alto_client.py**: `ALTOClient` — fetches and parses ALTO XML transcriptions into plain text
-- **clients/iiif_client.py**: `IIIFClient` — resolves IIIF collection manifests to discover page image URLs and identifiers
-- **clients/oai_pmh_client.py**: `OAIPMHClient` — fetches document metadata and IIIF manifest IDs via OAI-PMH protocol
-- **operations/browse_operations.py**: `BrowseOperations` — high-level orchestration: resolves reference code to assembled pages
-- **url_generator.py**: URL construction helpers for bildvisaren (image viewer), IIIF images, and ALTO XML
-- **config.py**: API base URLs, XML namespaces, and constants
+- **models.py**: Pydantic models — `BrowseResult` (full document browse result) and `PageContext` (single page with `full_text`, `image_url`, `alto_url`, `bildvisning_url`). `OAIPMHMetadata` is imported from `ra-mcp-oai-pmh-lib`.
+- **browse_operations.py**: `BrowseOperations` — high-level orchestration: resolves a reference code to assembled pages. Constructs `ALTOClient`, `OAIPMHClient`, and `IIIFClient` internally from the injected `HTTPClient`.
+- **url_generator.py**: URL construction helpers for bildvisning (image viewer), IIIF images, and ALTO XML
+- **utils.py**: Helpers such as `parse_page_range`
+- **config.py**: API base URLs and constants
+
+External clients used by `BrowseOperations` (each in its own package):
+
+- `ALTOClient` (`ra-mcp-xml`) — fetches and parses ALTO XML transcriptions into a text layer
+- `IIIFClient` (`ra-mcp-iiif-lib`) — resolves IIIF collection manifests to discover page image URLs and identifiers
+- `OAIPMHClient` (`ra-mcp-oai-pmh-lib`) — fetches document metadata and derives IIIF manifest IDs via OAI-PMH
 
 ## How the Clients Work Together
 
@@ -22,43 +26,51 @@ Contains the business logic for browsing and retrieving document page transcript
 Reference Code (e.g., SE/RA/420422/01)
     |
     v
-OAI-PMH Client --> metadata + IIIF manifest ID
+OAIPMHClient (ra-mcp-oai-pmh-lib) --> metadata + IIIF manifest ID
     |
     v
-IIIF Client    --> page list with image IDs
+IIIFClient (ra-mcp-iiif-lib)      --> page list with image IDs
     |
     v
-ALTO Client    --> transcribed text for each page
+ALTOClient (ra-mcp-xml)           --> transcribed text for each page
     |
     v
-BrowseResult   --> assembled pages with text + image links + metadata
+BrowseResult                      --> assembled pages with text + image links + metadata
 ```
 
 ## Usage
 
+`BrowseOperations.browse_document` is async and must be awaited.
+
 ```python
+import asyncio
+
 from ra_mcp_common.http_client import HTTPClient
-from ra_mcp_browse.browse_operations import BrowseOperations
+from ra_mcp_browse_lib.browse_operations import BrowseOperations
 
-ops = BrowseOperations(http_client=HTTPClient())
 
-result = ops.browse_document(
-    reference_code="SE/RA/420422/01",
-    pages="1-5",
-    highlight_term="Stockholm",
-    max_pages=20,
-)
+async def main():
+    ops = BrowseOperations(http_client=HTTPClient())
 
-for page in result.contexts:
-    print(f"Page {page.page_number}: {page.transcription[:100]}...")
-    print(f"  Image: {page.image_url}")
-    print(f"  Viewer: {page.bildvisaren_url}")
+    result = await ops.browse_document(
+        reference_code="SE/RA/420422/01",
+        pages="1-5",
+        highlight_term="Stockholm",
+        max_pages=20,
+    )
+
+    for page in result.contexts:
+        print(f"Page {page.page_number}: {page.full_text[:100]}...")
+        print(f"  Image: {page.image_url}")
+        print(f"  Viewer: {page.bildvisning_url}")
+
+
+asyncio.run(main())
 ```
 
 ## Dependencies
 
-- Internal: `ra-mcp-common`
-- External: `pydantic`
+- Internal: `ra-mcp-common`, `ra-mcp-xml`, `ra-mcp-iiif-lib`, `ra-mcp-oai-pmh-lib`
 
 ## Part of ra-mcp
 

--- a/packages/browse-mcp/README.md
+++ b/packages/browse-mcp/README.md
@@ -4,11 +4,13 @@ MCP tool for browsing Riksarkivet document pages.
 
 ## Overview
 
-Thin MCP wrapper around `ra-mcp-browse`. Registers the `browse_document` FastMCP tool that retrieves full page transcriptions with session-based deduplication, keyword highlighting, and LLM-friendly formatted output including links to the original images.
+Thin MCP wrapper around `ra-mcp-browse-lib`. Registers one FastMCP tool that retrieves full page transcriptions with session-based deduplication, keyword highlighting, and LLM-friendly formatted output including links to the original images.
+
+The tool is registered under the bare name `document` (see `@mcp.tool(name="document")` in `browse_tool.py`). When the root server composes this provider it adds the `browse` namespace, so clients of the composed server call it as `browse_document`. In standalone mode (running this server directly) the name is the bare `document`.
 
 ## MCP Tools
 
-### `browse_document`
+### `document` (namespaced: `browse_document`)
 
 View full page transcriptions by reference code. Returns original text (usually Swedish), links to bildvisaren (image viewer), and ALTO XML.
 
@@ -31,17 +33,20 @@ View full page transcriptions by reference code. Returns original text (usually 
 
 ## Standalone Usage
 
-```bash
-# stdio transport
-python -m ra_mcp_browse_mcp.server
+The default transport is HTTP (streamable-http) on port 3001. Pass `--stdio` for stdio transport.
 
-# HTTP transport
-python -m ra_mcp_browse_mcp.server --port 3002
+```bash
+# HTTP transport (default) — serves http://localhost:3001/mcp
+python -m ra_mcp_browse_mcp.server
+python -m ra_mcp_browse_mcp.server --port 3001
+
+# stdio transport
+python -m ra_mcp_browse_mcp.server --stdio
 ```
 
 ## Dependencies
 
-- Internal: `ra-mcp-browse`
+- Internal: `ra-mcp-browse-lib`
 - External: `fastmcp`
 
 ## Part of ra-mcp

--- a/packages/common/README.md
+++ b/packages/common/README.md
@@ -8,34 +8,47 @@ This is the foundation package with **no internal dependencies**. It provides th
 
 ## Components
 
-- **utils/http_client.py**: `HTTPClient` — urllib-based HTTP client with automatic retry (exponential backoff on 429/5xx), OpenTelemetry instrumentation, and configurable logging
-- **utils/formatting.py**: Shared formatting helpers (page ID parsing, error message formatting)
+- **http_client.py**: `HTTPClient` — async HTTP client built on `httpx.AsyncClient`, with automatic retry (exponential backoff on 429/5xx), connection pooling, optional HTTP/2, OpenTelemetry instrumentation, and configurable logging
+- **formatting.py**: Shared formatting helpers (page ID parsing, error message formatting)
+- **datasets.py**: `resolve_dataset_path(name)` — resolves a LanceDB dataset path with a four-step fallback: `<NAME>_LANCEDB_URI` env var → local `data/<name>/` (development) → `<RA_MCP_DATA_DIR>/<name>/` mount point (Docker) → `hf://datasets/carpelan/<name>-lance` (HuggingFace remote)
 - **telemetry.py**: `get_tracer()` and `get_meter()` — thin wrappers around the OpenTelemetry API that work as no-ops when the SDK is not initialized
 
 ## Usage
 
+The HTTP client is async — its methods are coroutines and must be awaited.
+
 ```python
+import asyncio
+
 from ra_mcp_common.http_client import HTTPClient
 
-client = HTTPClient()
 
-# JSON API calls
-data = client.get_json("https://data.riksarkivet.se/api/records", params={"q": "Stockholm"})
+async def main():
+    client = HTTPClient()  # optional: HTTPClient(http2=True) when the [http2] extra is installed
+    try:
+        # JSON API calls
+        data = await client.get_json("https://data.riksarkivet.se/api/records", params={"q": "Stockholm"})
 
-# XML responses (returns bytes)
-xml = client.get_xml("https://sok.riksarkivet.se/dokument/alto/...", timeout=30)
+        # XML responses (returns bytes)
+        xml = await client.get_xml("https://sok.riksarkivet.se/dokument/alto/...", timeout=30)
 
-# Raw content (returns None on 404/errors instead of raising)
-content = client.get_content("https://example.com/resource")
+        # Raw content (returns None on 404/errors instead of raising)
+        content = await client.get_content("https://example.com/resource")
+    finally:
+        await client.aclose()  # close the underlying httpx client
+
+
+asyncio.run(main())
 ```
 
 The default singleton `default_http_client` is used by all domain packages. For CLI commands with `--log`, use `get_http_client(enable_logging=True)`.
 
 ## HTTP Client Behavior
 
-- **Retry**: Automatic retry with exponential backoff on status codes 429, 500, 502, 503, 504 and on `TimeoutError`/`URLError`. Default: 3 retries, 0.5s base backoff.
+- **Retry**: Automatic retry with exponential backoff on status codes 429, 500, 502, 503, 504 and on `httpx.TimeoutException`/`httpx.ConnectError`. Default: 3 retries, 0.5s base backoff.
+- **Connection pooling**: Reuses connections via `httpx.AsyncClient` (max 20 connections, 10 keep-alive), follows redirects, and uses granular connect/read/write/pool timeouts.
 - **User-Agent**: `ra-mcp/{version}` (auto-detected from package metadata)
-- **Telemetry**: Every request produces an `HTTP GET` span plus counters for requests, errors, duration, and response size.
+- **Telemetry**: Every request produces an `HTTP GET` span plus counters for requests, errors, retries, duration, and response size.
 
 ## Environment Variables
 
@@ -44,10 +57,13 @@ The default singleton `default_http_client` is used by all domain packages. For 
 | `RA_MCP_LOG_API` | *(unset)* | Enable API call logging to `ra_mcp_api.log` |
 | `RA_MCP_LOG_LEVEL` | `INFO` | Logging level (DEBUG, INFO, WARNING, ERROR) |
 | `RA_MCP_TIMEOUT` | `60` | Override default request timeout in seconds |
+| `RA_MCP_DATA_DIR` | `/data` | Mount point searched by `datasets.py` for LanceDB datasets |
+| `<NAME>_LANCEDB_URI` | *(unset)* | Per-dataset override for `resolve_dataset_path` (e.g. `DDS_LANCEDB_URI`) |
 
 ## Dependencies
 
-- External: `opentelemetry-api`
+- External: `httpx>=0.28.0`, `opentelemetry-api>=1.28.0`
+- Optional extra: `[http2]` adds `httpx[http2]>=0.28.0` for HTTP/2 support
 
 ## Part of ra-mcp
 

--- a/packages/court-mcp/README.md
+++ b/packages/court-mcp/README.md
@@ -1,0 +1,71 @@
+# ra-mcp-court-mcp
+
+MCP tools for Swedish court records (Domboksregister & Medelstad) search.
+
+## Overview
+
+Thin MCP wrapper around `ra-mcp-court-lib`. Registers two FastMCP tools — `search_domboksregister` and `search_medelstad` — backed by a lazily-opened LanceDB connection. The dataset covers two härad court collections: Västra härad (Domboksregister) and Medelstad härad. Both tools run full-text search over the LanceDB tables and return LLM-formatted plain text.
+
+Tools are registered as bare names (`search_domboksregister`, `search_medelstad`) and get namespaced as `court:<tool>` when composed into the root server.
+
+## MCP Tools
+
+### `search_domboksregister`
+
+Search Västra härad court records 1611-1730 — 88,000 persons in court cases. Returns person name, role (plaintiff/defendant), title, parish, place, case notes, date, and case type.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across Domboksregister records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum records to return per query |
+| `roll` | str \| None | None | Optional filter: role in case (e.g. 'Kärande', 'Svarande'; substring match) |
+| `socken` | str \| None | None | Optional filter: parish name (case-insensitive substring match) |
+| `datum_from` | str \| None | None | Optional filter: date range start inclusive (string comparison on `datum`) |
+| `datum_till` | str \| None | None | Optional filter: date range end inclusive (string comparison on `datum`) |
+| `arende` | str \| None | None | Optional filter: case type (substring match on `arende`) |
+| `research_context` | str \| None | None | Brief summary of research goal (logging only) |
+
+### `search_medelstad`
+
+Search Medelstad härad court books 1668-1750 — 91,000 persons with 21,000 case summaries. Returns person name, title, parish, court date, case type, and full case summary text.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across Medelstad records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum records to return per query |
+| `mal_typ` | str \| None | None | Optional filter: case type (case-insensitive substring match) |
+| `norm_forsamling` | str \| None | None | Optional filter: parish name (case-insensitive substring match) |
+| `datum_from` | str \| None | None | Optional filter: date range start inclusive (string comparison on `ting_dag`) |
+| `datum_till` | str \| None | None | Optional filter: date range end inclusive (string comparison on `ting_dag`) |
+| `research_context` | str \| None | None | Brief summary of research goal (logging only) |
+
+## Components
+
+- **tools.py**: FastMCP server (`court_mcp`) setup, instructions, and tool registration
+- **domboksregister_tool.py**: `search_domboksregister` tool registration and LanceDB connection handling
+- **medelstad_tool.py**: `search_medelstad` tool registration and LanceDB connection handling
+- **formatter.py**: Formats Domboksregister and Medelstad results for LLM consumption
+- **server.py**: Standalone entry point for isolated dev/testing
+
+## Standalone Usage
+
+```bash
+# HTTP transport (default, streamable-http on /mcp)
+python -m ra_mcp_court_mcp.server --port 3008
+
+# stdio transport
+python -m ra_mcp_court_mcp.server --stdio
+```
+
+The default port is `3008` (overridable via the `PORT` environment variable or `--port`).
+
+## Dependencies
+
+- Internal: `ra-mcp-court-lib`
+- External: `fastmcp==3.1.1`
+
+## Part of ra-mcp
+
+Tools are registered as bare names and get namespaced as `court:<tool>` when composed into the root server via the `AVAILABLE_MODULES` registry. See the [docs site](https://ai-riksarkivet.github.io/ra-mcp/) for full project documentation.

--- a/packages/dds-mcp/README.md
+++ b/packages/dds-mcp/README.md
@@ -1,0 +1,88 @@
+# ra-mcp-dds-mcp
+
+MCP tools for Swedish church records (DDS) search — births, deaths, marriages.
+
+## Overview
+
+Thin MCP wrapper around `ra-mcp-dds-lib`. Registers three FastMCP tools — `search_fodelse`, `search_doda`, and `search_vigsel` — backed by a lazily-opened LanceDB connection. The dataset covers Swedish church records (Demografisk Databas Södra Sverige) for births/baptisms, deaths, and marriages from the 1600s to the early 1900s across multiple Swedish counties. Each tool runs full-text search over its LanceDB table and returns LLM-formatted plain text.
+
+Tools are registered as bare names (`search_fodelse`, `search_doda`, `search_vigsel`) and get namespaced as `dds:<tool>` when composed into the root server.
+
+## MCP Tools
+
+### `search_fodelse`
+
+Search Swedish birth/baptism records — 1.3 million records from 1600s-1914. Returns child name, gender, parents (father/mother names, occupations), birth/baptism date, parish, county, and birth place.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across birth/baptism records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum records to return per query |
+| `forsamling` | str \| None | None | Optional filter: parish name (case-insensitive substring match) |
+| `lan` | str \| None | None | Optional filter: county name (case-insensitive substring match) |
+| `kon` | str \| None | None | Optional filter: gender (e.g. 'Man', 'Kvinna'; substring match) |
+| `datum_from` | str \| None | None | Optional filter: earliest date (YYYY-MM-DD, inclusive) |
+| `datum_till` | str \| None | None | Optional filter: latest date (YYYY-MM-DD, inclusive) |
+| `research_context` | str \| None | None | Brief summary of research goal (logging only) |
+
+### `search_doda`
+
+Search Swedish death records — 950,000 records from 1600s-1951. Returns name, occupation, home parish, age, cause of death, relative information, and archive reference.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across death records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum records to return per query |
+| `forsamling` | str \| None | None | Optional filter: parish name (case-insensitive substring match) |
+| `lan` | str \| None | None | Optional filter: county name (case-insensitive substring match) |
+| `dodsorsak` | str \| None | None | Optional filter: cause of death (case-insensitive substring match) |
+| `datum_from` | str \| None | None | Optional filter: earliest date (YYYY-MM-DD, inclusive) |
+| `datum_till` | str \| None | None | Optional filter: latest date (YYYY-MM-DD, inclusive) |
+| `research_context` | str \| None | None | Brief summary of research goal (logging only) |
+
+### `search_vigsel`
+
+Search Swedish marriage records — 447,000 records from 1600s-1929. Returns bride and groom names, occupations, ages, civil status, home parishes, and banns dates.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across marriage records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum records to return per query |
+| `forsamling` | str \| None | None | Optional filter: parish name (case-insensitive substring match) |
+| `lan` | str \| None | None | Optional filter: county name (case-insensitive substring match) |
+| `datum_from` | str \| None | None | Optional filter: earliest date (YYYY-MM-DD, inclusive) |
+| `datum_till` | str \| None | None | Optional filter: latest date (YYYY-MM-DD, inclusive) |
+| `research_context` | str \| None | None | Brief summary of research goal (logging only) |
+
+## Components
+
+- **tools.py**: FastMCP server (`dds_mcp`) setup, instructions, and tool registration
+- **fodelse_tool.py**: `search_fodelse` tool registration and LanceDB connection handling
+- **doda_tool.py**: `search_doda` tool registration and LanceDB connection handling
+- **vigsel_tool.py**: `search_vigsel` tool registration and LanceDB connection handling
+- **formatter.py**: Formats birth, death, and marriage results for LLM consumption
+- **server.py**: Standalone entry point for isolated dev/testing
+
+## Standalone Usage
+
+```bash
+# HTTP transport (default, streamable-http on /mcp)
+python -m ra_mcp_dds_mcp.server --port 3013
+
+# stdio transport
+python -m ra_mcp_dds_mcp.server --stdio
+```
+
+The default port is `3013` (overridable via the `PORT` environment variable or `--port`).
+
+## Dependencies
+
+- Internal: `ra-mcp-dds-lib`
+- External: `fastmcp==3.1.1`
+
+## Part of ra-mcp
+
+Tools are registered as bare names and get namespaced as `dds:<tool>` when composed into the root server via the `AVAILABLE_MODULES` registry. See the [docs site](https://ai-riksarkivet.github.io/ra-mcp/) for full project documentation.

--- a/packages/diplomatics-mcp/README.md
+++ b/packages/diplomatics-mcp/README.md
@@ -1,0 +1,94 @@
+# ra-mcp-diplomatics-mcp
+
+MCP tools for SDHK and MPO medieval document search.
+
+## Overview
+
+Thin MCP wrapper around `ra-mcp-diplomatics-lib`. The composed server (`diplomatics_mcp` in `tools.py`) registers two FastMCP search tools — `search_sdhk` and `search_mpo` — backed by a lazily-opened LanceDB connection. The package also ships two viewer tools, `view_sdhk` and `view_mpo`, which open a single charter/fragment in the interactive document viewer (via `ra-mcp-viewer-mcp`); their register functions are present in the package but are not wired into `tools.py`. The dataset covers SDHK (Diplomatarium Suecanum) medieval Swedish charters and MPO (Medeltida Pergamentomslag) medieval parchment fragments.
+
+Tools are registered as bare names and get namespaced as `diplomatics:<tool>` when composed into the root server.
+
+## MCP Tools
+
+### `search_sdhk`
+
+Search SDHK (Diplomatarium Suecanum) — 44,000+ medieval Swedish charters dated before 1540 (about 15,000 digitized, with IIIF manifest URLs). Returns a markdown table with ID, date, place, author, summary, and status.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across SDHK charter text |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum records to return per query |
+| `author` | str \| None | None | Optional filter: charter author (case-insensitive substring match) |
+| `place` | str \| None | None | Optional filter: charter place (case-insensitive substring match) |
+| `language` | str \| None | None | Optional filter: charter language (case-insensitive substring match) |
+| `research_context` | str \| None | None | Brief summary of research goal (logging only) |
+
+### `search_mpo`
+
+Search MPO (Medeltida Pergamentomslag) — 23,000+ medieval parchment fragments used as bookbinding covers, each with a IIIF manifest URL. Returns a markdown table with ID, category, dating, origin, script, and content.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across MPO fragment text |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum records to return per query |
+| `category` | str \| None | None | Optional filter: fragment category (case-insensitive substring match) |
+| `institution` | str \| None | None | Optional filter: holding institution (case-insensitive substring match) |
+| `script` | str \| None | None | Optional filter: script type (case-insensitive substring match) |
+| `research_context` | str \| None | None | Brief summary of research goal (logging only) |
+
+### `view_sdhk`
+
+View a digitized SDHK charter in the document viewer with full metadata. Opens the interactive viewer with charter images and a metadata panel (author, date, summary, edition text, seal descriptions). Only works for digitized charters. *(Defined in `view_sdhk_tool.py`; not registered by `tools.py`.)*
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `sdhk_id` | int | *(required)* | SDHK charter ID (e.g. 85, 28672) |
+| `highlight_term` | str \| None | None | Optional search term to highlight |
+| `max_pages` | int | 20 | Maximum pages to load (≤ 20) |
+
+*(A FastMCP `ctx: Context` is injected automatically and is not a caller-supplied parameter.)*
+
+### `view_mpo`
+
+View an MPO parchment fragment in the document viewer with full codicological metadata (manuscript type, dating, script, material, content, decoration, damage). *(Defined in `view_mpo_tool.py`; not registered by `tools.py`.)*
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `mpo_id` | int | *(required)* | MPO fragment ID (e.g. 1, 42) |
+| `highlight_term` | str \| None | None | Optional search term to highlight |
+| `max_pages` | int | 20 | Maximum pages to load (≤ 20) |
+
+*(A FastMCP `ctx: Context` is injected automatically and is not a caller-supplied parameter.)*
+
+## Components
+
+- **tools.py**: FastMCP server (`diplomatics_mcp`) setup, instructions, and registration of the search tools
+- **sdhk_tool.py**: `search_sdhk` tool registration and LanceDB connection handling
+- **mpo_tool.py**: `search_mpo` tool registration and LanceDB connection handling
+- **view_sdhk_tool.py**: `view_sdhk` viewer tool registration (opens a charter in the document viewer)
+- **view_mpo_tool.py**: `view_mpo` viewer tool registration (opens a fragment in the document viewer)
+- **formatter.py**: Formats SDHK/MPO results and record info for LLM consumption
+- **server.py**: Standalone entry point for isolated dev/testing
+
+## Standalone Usage
+
+```bash
+# HTTP transport (default, streamable-http on /mcp)
+python -m ra_mcp_diplomatics_mcp.server --port 3003
+
+# stdio transport
+python -m ra_mcp_diplomatics_mcp.server --stdio
+```
+
+The default port is `3003` (overridable via the `PORT` environment variable or `--port`).
+
+## Dependencies
+
+- Internal: `ra-mcp-diplomatics-lib`, `ra-mcp-viewer-mcp`
+- External: `fastmcp==3.1.1`
+
+## Part of ra-mcp
+
+Tools are registered as bare names and get namespaced as `diplomatics:<tool>` when composed into the root server via the `AVAILABLE_MODULES` registry. See the [docs site](https://ai-riksarkivet.github.io/ra-mcp/) for full project documentation.

--- a/packages/faltjagare-mcp/README.md
+++ b/packages/faltjagare-mcp/README.md
@@ -1,0 +1,52 @@
+# ra-mcp-faltjagare-mcp
+
+MCP tools for Jämtland field regiment soldier records (Fältjägare) search.
+
+## Overview
+
+Thin MCP wrapper around `ra-mcp-faltjagare-lib`. Registers one FastMCP tool — `search_faltjagare` — which runs LanceDB full-text search over the Fältjägare soldier registry and formats results for LLM consumption. Tools are registered as bare names and get namespaced as `<module>:<tool>` when composed into the root server.
+
+## MCP Tools
+
+### `search_faltjagare`
+
+Search Jämtland field regiment soldier records (1645-1901). Returns soldier name, family name, rank, company, parish, region, service period, and fate (killed/died/deserted).
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across soldier records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum number of records to return per query |
+| `kompani` | str \| None | None | Filter: company name (case-insensitive substring match) |
+| `region` | str \| None | None | Filter: region (e.g. `Jämtland`, `Härjedalen`) |
+| `befattning` | str \| None | None | Filter: rank/position (e.g. `Soldat`, `Korpral`) |
+| `research_context` | str \| None | None | Brief research goal (logging only) |
+
+## Components
+
+- **tools.py**: FastMCP server (`faltjagare_mcp`) setup, instructions, and tool registration
+- **faltjagare_tool.py**: `search_faltjagare` tool registration, lazy LanceDB connection, input validation
+- **formatter.py**: `format_faltjagare_results` — formats search results for LLM output
+- **server.py**: Standalone entry point for isolated dev/testing
+
+## Standalone Usage
+
+```bash
+# HTTP transport (default, port 3010)
+python -m ra_mcp_faltjagare_mcp.server
+
+# HTTP transport on a custom port
+python -m ra_mcp_faltjagare_mcp.server --port 3010
+
+# stdio transport
+python -m ra_mcp_faltjagare_mcp.server --stdio
+```
+
+## Dependencies
+
+- Internal: `ra-mcp-faltjagare-lib` (backed by `ra-mcp-common` for dataset path resolution)
+- External: `fastmcp`
+
+## Part of ra-mcp
+
+Registered into the root composition server, where its bare tool name is namespaced as `<module>:<tool>` (e.g. `faltjagare:search_faltjagare`). See the [docs site](https://ai-riksarkivet.github.io/ra-mcp/) for full project documentation.

--- a/packages/filmcensur-mcp/README.md
+++ b/packages/filmcensur-mcp/README.md
@@ -1,0 +1,52 @@
+# ra-mcp-filmcensur-mcp
+
+MCP tools for Swedish film censorship records (Filmcensur) search.
+
+## Overview
+
+Thin MCP wrapper around `ra-mcp-filmcensur-lib`. Registers one FastMCP tool — `search_filmreg` — which runs LanceDB full-text search over the Swedish film censorship registry (films reviewed by Statens biografbyrå, 1911-2011) and formats results for LLM consumption. Tools are registered as bare names and get namespaced as `<module>:<tool>` when composed into the root server.
+
+## MCP Tools
+
+### `search_filmreg`
+
+Search Swedish film censorship records. Returns original and Swedish titles, production year/country, category, age rating, number of cuts, producer, free-text descriptions, and notes.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across film censorship records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum number of records to return per query |
+| `filmkategori` | str \| None | None | Filter: film category (e.g. `Spelfilm`, `Dokumentär`) |
+| `produktionsland` | str \| None | None | Filter: production country (e.g. `Sverige`, `USA`) |
+| `aaldersgraens` | str \| None | None | Filter: age rating (e.g. `15 år`, `Barntillåten`) |
+| `research_context` | str \| None | None | Brief research goal (logging only) |
+
+## Components
+
+- **tools.py**: FastMCP server (`filmcensur_mcp`) setup, instructions, and tool registration
+- **filmreg_tool.py**: `search_filmreg` tool registration, lazy LanceDB connection, input validation
+- **formatter.py**: `format_filmreg_results` — formats search results for LLM output
+- **server.py**: Standalone entry point for isolated dev/testing
+
+## Standalone Usage
+
+```bash
+# HTTP transport (default, port 3006)
+python -m ra_mcp_filmcensur_mcp.server
+
+# HTTP transport on a custom port
+python -m ra_mcp_filmcensur_mcp.server --port 3006
+
+# stdio transport
+python -m ra_mcp_filmcensur_mcp.server --stdio
+```
+
+## Dependencies
+
+- Internal: `ra-mcp-filmcensur-lib` (backed by `ra-mcp-common` for dataset path resolution)
+- External: `fastmcp`
+
+## Part of ra-mcp
+
+Registered into the root composition server, where its bare tool name is namespaced as `<module>:<tool>` (e.g. `filmcensur:search_filmreg`). See the [docs site](https://ai-riksarkivet.github.io/ra-mcp/) for full project documentation.

--- a/packages/guide-mcp/README.md
+++ b/packages/guide-mcp/README.md
@@ -39,11 +39,14 @@ Use the table of contents resource to discover all available sections.
 ## Standalone Usage
 
 ```bash
-# stdio transport
+# HTTP transport (default, port 3001)
 python -m ra_mcp_guide_mcp.server
 
-# HTTP transport
+# HTTP transport on a custom port
 python -m ra_mcp_guide_mcp.server --port 3003
+
+# stdio transport
+python -m ra_mcp_guide_mcp.server --stdio
 ```
 
 ## Dependencies

--- a/packages/htr-mcp/README.md
+++ b/packages/htr-mcp/README.md
@@ -53,7 +53,7 @@ python -m ra_mcp_htr_mcp.server --port 3002
 
 ## Dependencies
 
-- External: `fastmcp`, `gradio-client`, `pydantic`
+- External: `fastmcp`, `gradio-client`
 
 ## Part of ra-mcp
 

--- a/packages/label-mcp/README.md
+++ b/packages/label-mcp/README.md
@@ -1,3 +1,68 @@
 # ra-mcp-label-mcp
 
-MCP tool for converting ALTO XML transcriptions to Label Studio pre-annotation tasks (VectorLabels format).
+MCP tool for importing Riksarkivet document pages into Label Studio as annotation tasks.
+
+## Overview
+
+Registers a single FastMCP tool — `import_to_label_studio` — that pushes document pages to a Label Studio project for human annotation. It supports two modes:
+
+- **ALTO pre-annotation**: given ALTO XML URLs (paired with image URLs), it fetches the XML, converts each page to VectorLabels polygons with transcriptions, and imports them as pre-annotated tasks ready for review and correction.
+- **Image-only**: given image URLs alone, it creates blank tasks (just the image) for annotation from scratch.
+
+Pages can optionally be assigned to a Label Studio user, tagged with per-page feedback choices (`Transcription` / `Segmentation`), or previewed as JSON without importing (`dry_run`). Connection settings (URL, token, project) can be passed as arguments or supplied via environment variables (a `.env` file in the package root is auto-loaded).
+
+## MCP Tools
+
+### `import_to_label_studio`
+
+Import pages to a Label Studio project for human annotation. Returns a summary with per-task links, or — in dry-run mode — the converted tasks as JSON.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `image_urls` | list[str] | *(required)* | Image URLs to import (one per page) |
+| `alto_urls` | list[str] \| None | None | ALTO XML URLs paired by index with `image_urls`. If provided, creates pre-annotated VectorLabels tasks; if omitted, creates blank image-only tasks |
+| `feedback` | list[list[str]] \| None | None | Per-page feedback choices (`Transcription`, `Segmentation`), paired by index. Requires `alto_urls` |
+| `ls_url` | str \| None | None | Label Studio URL (falls back to `LS_URL`) |
+| `ls_token` | str \| None | None | Label Studio access token (falls back to `LS_TOKEN`) |
+| `project_id` | int \| None | None | Label Studio project ID (falls back to `LS_PROJECT_ID`) |
+| `assign_to` | str \| None | None | Email of a Label Studio user to assign the imported tasks to |
+| `dry_run` | bool | False | If true, return the converted tasks as JSON without importing |
+
+Validation: `alto_urls` must match `image_urls` in length; `feedback` must match `alto_urls` in length and requires `alto_urls`.
+
+## Components
+
+- **label_tool.py**: `register_label_tool` — `import_to_label_studio` tool, mode selection, validation, import/assign orchestration, and `.env` autoload
+- **converter.py**: `convert_alto_to_tasks` / `tasks_to_json` — ALTO XML → VectorLabels pre-annotation tasks
+- **ls_client.py**: `import_tasks` / `assign_tasks` — Label Studio SDK calls
+- **tools.py**: FastMCP server setup and tool registration
+- **server.py**: Standalone entry point for isolated dev/testing
+
+## Environment Variables
+
+| Variable | Description |
+|----------|-------------|
+| `LS_URL` | Label Studio base URL (e.g. `https://your-ls.hf.space`) |
+| `LS_TOKEN` | Label Studio access token |
+| `LS_PROJECT_ID` | Default Label Studio project ID |
+
+A `.env` file in the package root is auto-loaded at import time (existing environment variables take precedence).
+
+## Standalone Usage
+
+```bash
+# stdio transport (default)
+python -m ra_mcp_label_mcp.server
+
+# HTTP transport
+python -m ra_mcp_label_mcp.server --port 3003
+```
+
+## Dependencies
+
+- Internal: `ra-mcp-common`
+- External: `fastmcp`, `httpx`, `label-studio-sdk`
+
+## Part of ra-mcp
+
+Imported by the root server via `FastMCP.add_provider()` with namespace `label`. See the [docs site](https://ai-riksarkivet.github.io/ra-mcp/) for full project documentation.

--- a/packages/pdf-mcp/README.md
+++ b/packages/pdf-mcp/README.md
@@ -1,0 +1,86 @@
+# ra-mcp-pdf-mcp
+
+Interactive PDF viewer MCP App with search, block overlays, and PDF.js rendering.
+
+## Overview
+
+An MCP App that renders an interactive PDF viewer (Svelte UI + PDF.js) directly inside the MCP host (Claude, ChatGPT, etc.). Uses FastMCP's `AppConfig` to serve a self-contained HTML/JS viewer that streams PDF bytes on demand, renders pages with PDF.js, and overlays structured text blocks with highlightable search matches.
+
+The package ships a curated gallery of Riksarkivet archival PDF guides (medieval Sweden, governance, Sami history, genealogy, and more). When a PDF is opened, its DataLab block JSON is prefetched and cached so search and page-text extraction are fast and server-side. The guide JSONs are preloaded into a block cache, which lets `search_guides` and `read_pdf_page` work across all guides without first opening a viewer. View state is held in an async key-value store so the UI can poll for LLM-initiated changes (navigation, highlight).
+
+## MCP Tools
+
+### Open and read (user-visible)
+
+| Tool | Key parameters | Purpose |
+|------|----------------|---------|
+| `display_pdf` | `url=<default guide>`, `title?` | **Required first step** to open a PDF in the viewer; schedules prefetch of block data |
+| `list_pdfs` | *(none)* | List the curated gallery of available Riksarkivet PDF guides |
+| `search_guides` | `term` | Search across ALL preloaded guides at once (no `display_pdf` needed); returns guide title, page, snippets |
+| `read_pdf_page` | `url`, `page`, `count=1` (max 5) | Read structured text for one or more pages (loads gallery PDFs on demand) |
+| `search_pdf` | `url`, `term` | Search all pages of a loaded PDF; per-page match counts and snippets (requires `display_pdf`) |
+
+### Control an open viewer (user-visible)
+
+| Tool | Key parameters | Purpose |
+|------|----------------|---------|
+| `pdf_set_search` | `search_term` | Highlight a term (or clear with `""`) in the open viewer (requires `display_pdf`) |
+| `pdf_go_to_page` | `page` | Navigate the open viewer to a page (requires `display_pdf`) |
+
+### Used by the viewer UI (app-visible only)
+
+| Tool | Key parameters | Purpose |
+|------|----------------|---------|
+| `read_pdf_bytes` | `url`, `offset=0` | Stream a chunk of PDF bytes (base64) with pagination metadata |
+| `get_pdf_state` | `view_id` | Poll current viewer state by view id |
+| `get_page_blocks` | `url`, `page` | Get structured blocks (bbox + type) for a page for overlay rendering |
+
+## Architecture
+
+This is an **MCP App** — it uses FastMCP's `AppConfig` and a `ui://` resource:
+
+```
+Model calls display_pdf
+    |
+    v
+Tool persists PdfViewerState, schedules block prefetch, returns text summary (model) + structured content (UI)
+    |
+    v
+MCP host renders ui://pdf-viewer/mcp-app.html
+    |
+    v
+Viewer UI streams read_pdf_bytes, fetches get_page_blocks, polls get_pdf_state on demand
+```
+
+The HTML viewer is built into `src/ra_mcp_pdf_mcp/dist/mcp-app.html` and served as the `ui://pdf-viewer/mcp-app.html` resource, with a Content-Security-Policy that allows the Hugging Face domains the gallery PDFs are hosted on.
+
+## Components
+
+- **tools.py**: Tool and resource registrations (all `*_pdf*` tools plus the UI resource)
+- **cache.py**: Chunked PDF byte fetching (`read_pdf_range`), block cache, prefetch scheduling, and guide preloading (`preload_all_guides`)
+- **gallery.py**: The curated gallery of Riksarkivet PDF guides (`GALLERY_ITEMS`, `get_gallery_items`)
+- **search.py**: Block-level page search (`search_pages`) and HTML-to-text extraction
+- **models.py**: `PdfViewerState` and related data models
+- **state.py**: Async key-value store for viewer state (`get_state`, `put_state`, `get_active_state`)
+- **server.py**: Standalone entry point for isolated dev/testing
+
+## Standalone Usage
+
+```bash
+# HTTP transport (default, port 3001)
+python -m ra_mcp_pdf_mcp.server
+
+# HTTP transport on a custom port
+python -m ra_mcp_pdf_mcp.server --port 3001
+
+# stdio transport
+python -m ra_mcp_pdf_mcp.server --stdio
+```
+
+## Dependencies
+
+- External: `httpx[http2]`, `fastmcp`, `py-key-value-aio[memory]`
+
+## Part of ra-mcp
+
+Imported by the root server via `FastMCP.add_provider()` with no namespace (tools are registered at the root level). Enabled by default. See the [docs site](https://ai-riksarkivet.github.io/ra-mcp/) for full project documentation.

--- a/packages/rosenberg-mcp/README.md
+++ b/packages/rosenberg-mcp/README.md
@@ -1,0 +1,51 @@
+# ra-mcp-rosenberg-mcp
+
+MCP tools for Rosenberg's geographical lexicon of Sweden.
+
+## Overview
+
+Thin MCP wrapper around `ra-mcp-rosenberg-lib`. Registers one FastMCP tool — `search_rosenberg` — which runs LanceDB full-text search over Rosenberg's *Geografiskt-statistiskt handlexikon öfver Sverige* (historical Swedish places and their descriptions) and formats results for LLM consumption. Tools are registered as bare names and get namespaced as `<module>:<tool>` when composed into the root server.
+
+## MCP Tools
+
+### `search_rosenberg`
+
+Search Rosenberg's geographical lexicon of Sweden. Returns place name, parish, hundred, county, full description text, and industry/feature flags.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across the lexicon |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum number of records to return per query |
+| `lan` | str \| None | None | Filter: county/län (e.g. `Stockholms`, `Malmöhus`) |
+| `forsamling` | str \| None | None | Filter: parish/församling (e.g. `Klara`, `Hedvig`) |
+| `research_context` | str \| None | None | Brief research goal (logging only) |
+
+## Components
+
+- **tools.py**: FastMCP server (`rosenberg_mcp`) setup, instructions, and tool registration
+- **rosenberg_tool.py**: `search_rosenberg` tool registration, lazy LanceDB connection, input validation
+- **formatter.py**: `format_rosenberg_results` — formats search results for LLM output
+- **server.py**: Standalone entry point for isolated dev/testing
+
+## Standalone Usage
+
+```bash
+# HTTP transport (default, port 3007)
+python -m ra_mcp_rosenberg_mcp.server
+
+# HTTP transport on a custom port
+python -m ra_mcp_rosenberg_mcp.server --port 3007
+
+# stdio transport
+python -m ra_mcp_rosenberg_mcp.server --stdio
+```
+
+## Dependencies
+
+- Internal: `ra-mcp-rosenberg-lib` (backed by `ra-mcp-common` for dataset path resolution)
+- External: `fastmcp`
+
+## Part of ra-mcp
+
+Registered into the root composition server, where its bare tool name is namespaced as `<module>:<tool>` (e.g. `rosenberg:search_rosenberg`). See the [docs site](https://ai-riksarkivet.github.io/ra-mcp/) for full project documentation.

--- a/packages/sbl-mcp/README.md
+++ b/packages/sbl-mcp/README.md
@@ -1,0 +1,86 @@
+# ra-mcp-sbl-mcp
+
+MCP tools for Svenskt biografiskt lexikon (SBL) search.
+
+## Overview
+
+Thin MCP wrapper around `ra-mcp-sbl-lib`. Registers four FastMCP tools — `search_sbl`, `view_sbl_article`, `load_sbl_article`, and `get_sbl_state` — plus a UI resource for a rich article viewer (MCP App). `search_sbl` runs LanceDB full-text search over SBL biographical articles; the view/load/state tools drive an interactive article viewer. Tools are registered as bare names and get namespaced as `<module>:<tool>` when composed into the root server.
+
+## MCP Tools
+
+### `search_sbl`
+
+Search Svenskt biografiskt lexikon biographical articles. Returns name, occupation, career details (CV/meriter), birth/death dates and places, sources, and portrait image URLs. SBL text uses printed-encyclopedia abbreviations (e.g. `f`=född, `d`=död, `Sthlm`=Stockholm) that should be expanded when presenting.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across SBL articles |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum number of records to return per query |
+| `gender` | str \| None | None | Filter: `m` (male), `f` (female), or `-` (family/other), exact match |
+| `occupation` | str \| None | None | Filter: occupation (case-insensitive substring match) |
+| `birth_place` | str \| None | None | Filter: birth place (case-insensitive substring match) |
+| `death_place` | str \| None | None | Filter: death place (case-insensitive substring match) |
+| `birth_year_min` | int \| None | None | Filter: minimum birth year (inclusive) |
+| `birth_year_max` | int \| None | None | Filter: maximum birth year (inclusive) |
+| `death_year_min` | int \| None | None | Filter: minimum death year (inclusive) |
+| `death_year_max` | int \| None | None | Filter: maximum death year (inclusive) |
+| `research_context` | str \| None | None | Brief research goal (logging only) |
+
+### `view_sbl_article`
+
+Display an SBL article in a rich viewer (creates a new viewer; model- and app-visible). Takes an `article_id` from `search_sbl` results and shows the full article with portrait, career details, printed works, sources, and a link to the full biography on the SBL website.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `article_id` | int | *(required)* | The SBL article ID from `search_sbl` results |
+
+### `load_sbl_article`
+
+Load an SBL article into the viewer in place (app-only, for cross-reference navigation).
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `article_id` | int | *(required)* | The SBL article ID to load |
+| `view_id` | str | `""` | The view ID from the initial tool result |
+
+### `get_sbl_state`
+
+Return the current article for a specific view (app-only, polling endpoint for LLM-initiated loads).
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `view_id` | str | `""` | The view ID to get state for |
+
+## Components
+
+- **tools.py**: FastMCP server (`sbl_mcp`) setup, instructions, and registration of both the search and viewer tools
+- **sbl_tool.py**: `search_sbl` tool registration, lazy LanceDB connection, input validation
+- **view_tool.py**: `view_sbl_article`, `load_sbl_article`, `get_sbl_state` tools and the `ui://sbl-article-viewer/mcp-app.html` UI resource
+- **state.py**: Per-view in-memory state store for the article viewer
+- **formatter.py**: `format_sbl_results` — formats search results for LLM output
+- **server.py**: Standalone entry point for isolated dev/testing
+
+## Standalone Usage
+
+```bash
+# HTTP transport (default, port 3004)
+python -m ra_mcp_sbl_mcp.server
+
+# HTTP transport on a custom port
+python -m ra_mcp_sbl_mcp.server --port 3004
+
+# stdio transport
+python -m ra_mcp_sbl_mcp.server --stdio
+```
+
+The viewer UI is served from a built bundle in `src/ra_mcp_sbl_mcp/dist/`; run `npm run build` in `packages/sbl-mcp/` if the resource is missing.
+
+## Dependencies
+
+- Internal: `ra-mcp-sbl-lib` (backed by `ra-mcp-common` for dataset path resolution)
+- External: `fastmcp`
+
+## Part of ra-mcp
+
+Registered into the root composition server, where each bare tool name is namespaced as `<module>:<tool>` (e.g. `sbl:search_sbl`, `sbl:view_sbl_article`). See the [docs site](https://ai-riksarkivet.github.io/ra-mcp/) for full project documentation.

--- a/packages/search-cli/README.md
+++ b/packages/search-cli/README.md
@@ -21,8 +21,8 @@ ra search "Stockholm" --log
 
 | Flag | Default | Description |
 |------|---------|-------------|
-| `--limit` | 25 | Maximum records to fetch from API (pagination size) |
-| `--max-display` | 10 | Maximum records to display in output |
+| `--limit` | 50 | Maximum records to fetch from API (pagination size) |
+| `--max-display` | 20 | Maximum records to display in output |
 | `--max-hits-per-vol` | 3 | Limit hits per volume (useful for broad searches) |
 | `--transcribed-text` / `--text` | `--transcribed-text` | Search AI-transcribed text (default) or metadata fields |
 | `--only-digitised-materials` / `--include-all-materials` | `--only-digitised-materials` | Limit to digitised materials or include all records |
@@ -38,7 +38,7 @@ ra search "Stockholm" --log
 
 ## Dependencies
 
-- Internal: `ra-mcp-search`
+- Internal: `ra-mcp-search-lib`
 - External: `typer`, `rich`
 
 ## Part of ra-mcp

--- a/packages/search-lib/README.md
+++ b/packages/search-lib/README.md
@@ -1,4 +1,4 @@
-# ra-mcp-search
+# ra-mcp-search-lib
 
 Search domain package for Riksarkivet transcribed documents.
 
@@ -9,34 +9,43 @@ Contains the business logic for searching the Swedish National Archives. This is
 ## Components
 
 - **models.py**: Pydantic models — `SearchRecord` (single result with metadata + transcribed text snippets), `RecordsResponse` (API response wrapper), `SearchResult` (paginated result set)
-- **clients/search_client.py**: `SearchAPI` — client for the Riksarkivet records API (`https://data.riksarkivet.se/api/records`)
-- **operations/search_operations.py**: `SearchOperations` — high-level search orchestration with pagination, filtering, and dedup support
-- **config.py**: API URL, default limit (25), and max display (10) constants
+- **search_client.py**: `SearchClient` — client for the Riksarkivet records API (`https://data.riksarkivet.se/api/records`)
+- **search_operations.py**: `SearchOperations` — high-level search orchestration with pagination, filtering, and dedup support
+- **config.py**: API URL, default limit (`DEFAULT_LIMIT=50`), and max display (`DEFAULT_MAX_DISPLAY=20`) constants
 
 ## Usage
 
+`SearchOperations.search` is async and must be awaited.
+
 ```python
+import asyncio
+
 from ra_mcp_common.http_client import HTTPClient
-from ra_mcp_search.search_operations import SearchOperations
+from ra_mcp_search_lib.search_operations import SearchOperations
 
-ops = SearchOperations(http_client=HTTPClient())
 
-result = ops.search(
-    keyword="trolldom",
-    transcribed_only=True,
-    only_digitised=True,
-    offset=0,
-    limit=25,
-    sort="relevance",
-    year_min=1600,
-    year_max=1700,
-)
+async def main():
+    ops = SearchOperations(http_client=HTTPClient())
 
-for record in result.items:
-    print(record.metadata.reference_code, record.metadata.title)
-    if record.transcribed_text:
-        for snippet in record.transcribed_text.snippets:
-            print(f"  Page {snippet.pages[0].id}: {snippet.text[:100]}...")
+    result = await ops.search(
+        keyword="trolldom",
+        transcribed_only=True,
+        only_digitised=True,
+        offset=0,
+        limit=50,
+        sort="relevance",
+        year_min=1600,
+        year_max=1700,
+    )
+
+    for record in result.items:
+        print(record.metadata.reference_code, record.metadata.title)
+        if record.transcribed_text:
+            for snippet in record.transcribed_text.snippets:
+                print(f"  Page {snippet.pages[0].id}: {snippet.text[:100]}...")
+
+
+asyncio.run(main())
 ```
 
 ## Search Modes
@@ -47,7 +56,6 @@ for record in result.items:
 ## Dependencies
 
 - Internal: `ra-mcp-common`
-- External: `pydantic`
 
 ## Part of ra-mcp
 

--- a/packages/search-mcp/README.md
+++ b/packages/search-mcp/README.md
@@ -4,11 +4,13 @@ MCP tools for searching Riksarkivet transcribed documents.
 
 ## Overview
 
-Thin MCP wrapper around `ra-mcp-search`. Registers two FastMCP tools — `search_transcribed` and `search_metadata` — with full parameter validation, session-based deduplication, pagination info, and LLM-friendly formatted output.
+Thin MCP wrapper around `ra-mcp-search-lib`. Registers two FastMCP tools with full parameter validation, session-based deduplication, pagination info, and LLM-friendly formatted output.
+
+The tools are registered under bare names — `transcribed` and `metadata` (see `@mcp.tool(name=...)` in `search_tool.py`). When the root server composes this provider it adds the `search` namespace, so clients of the composed server call them as `search_transcribed` and `search_metadata`. In standalone mode (running this server directly) the names are the bare `transcribed` and `metadata`.
 
 ## MCP Tools
 
-### `search_transcribed`
+### `transcribed` (namespaced: `search_transcribed`)
 
 Search AI-transcribed text across ~1.6M digitised pages. Supports Solr query syntax: wildcards (`troll*`), fuzzy (`stockholm~1`), Boolean (`(A AND B)`), proximity (`"term1 term2"~10`).
 
@@ -17,26 +19,32 @@ Search AI-transcribed text across ~1.6M digitised pages. Supports Solr query syn
 | `keyword` | str | *(required)* | Search term or Solr query |
 | `offset` | int | *(required)* | Pagination start (0, 50, 100...) |
 | `limit` | int | 25 | Documents per page |
+| `max_snippets_per_record` | int | 3 | Max matching pages per document |
+| `max_response_tokens` | int | 15000 | Response token budget |
 | `sort` | str | `relevance` | `relevance`, `timeAsc`, `timeDesc`, `alphaAsc`, `alphaDesc` |
 | `year_min` | int \| None | None | Start year filter |
 | `year_max` | int \| None | None | End year filter |
-| `max_snippets_per_record` | int | 3 | Max matching pages per document |
-| `max_response_tokens` | int | 15000 | Response token budget |
 | `dedup` | bool | True | Session deduplication |
 | `research_context` | str \| None | None | Research goal (telemetry) |
 
-### `search_metadata`
+### `metadata` (namespaced: `search_metadata`)
 
-Search document metadata (titles, names, places, descriptions) across 2M+ catalog records.
+Search document metadata (titles, names, places, descriptions) across 2M+ catalog records. Unlike `transcribed`, this tool has no `max_snippets_per_record` parameter (metadata search returns no page snippets).
 
 | Parameter | Type | Default | Description |
 |-----------|------|---------|-------------|
 | `keyword` | str | *(required)* | Free-text search |
 | `offset` | int | *(required)* | Pagination start |
+| `only_digitised` | bool | True | Limit to digitised materials |
+| `limit` | int | 25 | Documents per page |
+| `max_response_tokens` | int | 15000 | Response token budget |
+| `sort` | str | `relevance` | `relevance`, `timeAsc`, `timeDesc`, `alphaAsc`, `alphaDesc` |
+| `year_min` | int \| None | None | Start year filter |
+| `year_max` | int \| None | None | End year filter |
 | `name` | str \| None | None | Person name filter |
 | `place` | str \| None | None | Place name filter |
-| `only_digitised` | bool | True | Limit to digitised materials |
-| *(plus same shared params as search_transcribed)* | | | |
+| `dedup` | bool | True | Session deduplication |
+| `research_context` | str \| None | None | Research goal (telemetry) |
 
 ## Components
 
@@ -46,17 +54,20 @@ Search document metadata (titles, names, places, descriptions) across 2M+ catalo
 
 ## Standalone Usage
 
-```bash
-# stdio transport
-python -m ra_mcp_search_mcp.server
+The default transport is HTTP (streamable-http) on port 3001. Pass `--stdio` for stdio transport.
 
-# HTTP transport
+```bash
+# HTTP transport (default) — serves http://localhost:3001/mcp
+python -m ra_mcp_search_mcp.server
 python -m ra_mcp_search_mcp.server --port 3001
+
+# stdio transport
+python -m ra_mcp_search_mcp.server --stdio
 ```
 
 ## Dependencies
 
-- Internal: `ra-mcp-search`
+- Internal: `ra-mcp-search-lib`
 - External: `fastmcp`
 
 ## Part of ra-mcp

--- a/packages/sj-mcp/README.md
+++ b/packages/sj-mcp/README.md
@@ -1,0 +1,63 @@
+# ra-mcp-sj-mcp
+
+MCP tools for Swedish State Railways (SJ) records search.
+
+## Overview
+
+Thin MCP wrapper around `ra-mcp-sj-lib`. Registers two FastMCP tools — `search_juda` and `search_ritningar` — that run full-text search over a local LanceDB copy of the SJ railway property register (JUDA) and the FIRA/SIRA technical drawing registers. Tools are registered as bare names and get namespaced as `<module>:<tool>` when composed into the root server.
+
+## MCP Tools
+
+### `search_juda`
+
+Search the SJ railway property register (JUDA) — railway properties managed by Swedish State Railways. Returns property description, county, municipality, owner, and notes.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across JUDA railway property records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum records per query |
+| `fbagrkod2` | str \| None | None | Filter: owner code (case-insensitive substring match, e.g. `Jernhusen`) |
+| `research_context` | str \| None | None | Research goal summary (logging only) |
+
+### `search_ritningar`
+
+Search SJ railway technical drawings (FIRA/SIRA) of stations, buildings, and infrastructure. Returns station/building name, description, drawing number, date, format, district, and building type.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across FIRA/SIRA railway drawing records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum records per query |
+| `dkod` | str \| None | None | Filter: district code (case-insensitive substring match) |
+| `research_context` | str \| None | None | Research goal summary (logging only) |
+
+## Components
+
+- **tools.py**: FastMCP server setup, instructions, and tool registration
+- **juda_tool.py**: `search_juda` tool — registration, validation, lazy LanceDB connection
+- **ritningar_tool.py**: `search_ritningar` tool — registration, validation, lazy LanceDB connection
+- **formatter.py**: Formats JUDA and Ritningar search results for LLM consumption
+- **server.py**: Standalone entry point for isolated dev/testing
+
+## Standalone Usage
+
+```bash
+# HTTP transport (default, port 3015)
+python -m ra_mcp_sj_mcp.server
+
+# HTTP transport on a custom port
+python -m ra_mcp_sj_mcp.server --port 8080
+
+# stdio transport
+python -m ra_mcp_sj_mcp.server --stdio
+```
+
+## Dependencies
+
+- Internal: `ra-mcp-sj-lib` (which depends on `ra-mcp-common`)
+- External: `fastmcp`
+
+## Part of ra-mcp
+
+Composed into the root server alongside the other dataset modules. Tools are registered as bare names (`search_juda`, `search_ritningar`) and get namespaced as `<module>:<tool>` in the composed server. See the [docs site](https://ai-riksarkivet.github.io/ra-mcp/) for full project documentation.

--- a/packages/sjomanshus-mcp/README.md
+++ b/packages/sjomanshus-mcp/README.md
@@ -1,0 +1,69 @@
+# ra-mcp-sjomanshus-mcp
+
+MCP tools for Swedish seamen's house records (Sjömanshus) search.
+
+## Overview
+
+Thin MCP wrapper around `ra-mcp-sjomanshus-lib`. Registers two FastMCP tools — `search_liggare` and `search_matrikel` — that run full-text search over a local LanceDB copy of the Swedish seamen's house records: voyage records (Liggare) and registration records (Matrikel) from the 1700s–1900s. Tools are registered as bare names and get namespaced as `<module>:<tool>` when composed into the root server.
+
+## MCP Tools
+
+### `search_liggare`
+
+Search Swedish seamen's voyage records (Liggare). Returns seaman name, rank, ship, home port, destination, captain, and shipowner.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across Liggare voyage records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum records per query |
+| `befattning` | str \| None | None | Filter: occupation/rank (case-insensitive substring, e.g. `matros`, `styrman`) |
+| `fartyg` | str \| None | None | Filter: ship name (case-insensitive substring) |
+| `sjoemanshus` | str \| None | None | Filter: seamen's house name (case-insensitive substring, e.g. `Göteborg`) |
+| `hemmahamn` | str \| None | None | Filter: home port (case-insensitive substring) |
+| `kapten` | str \| None | None | Filter: captain name (case-insensitive substring) |
+| `redare` | str \| None | None | Filter: shipowner name (case-insensitive substring) |
+| `destination` | str \| None | None | Filter: voyage destination (case-insensitive substring, e.g. `Medelhavet`) |
+| `research_context` | str \| None | None | Research goal summary (logging only) |
+
+### `search_matrikel`
+
+Search Swedish seamen's registration records (Matrikel). Returns seaman name, birth info, parents, home parish, and registration/deregistration dates.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across Matrikel registration records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum records per query |
+| `sjoemanshus` | str \| None | None | Filter: seamen's house name (case-insensitive substring, e.g. `Göteborg`) |
+| `research_context` | str \| None | None | Research goal summary (logging only) |
+
+## Components
+
+- **tools.py**: FastMCP server setup, instructions, and tool registration
+- **liggare_tool.py**: `search_liggare` tool — registration, validation, lazy LanceDB connection
+- **matrikel_tool.py**: `search_matrikel` tool — registration, validation, lazy LanceDB connection
+- **formatter.py**: Formats Liggare and Matrikel search results for LLM consumption
+- **server.py**: Standalone entry point for isolated dev/testing
+
+## Standalone Usage
+
+```bash
+# HTTP transport (default, port 3005)
+python -m ra_mcp_sjomanshus_mcp.server
+
+# HTTP transport on a custom port
+python -m ra_mcp_sjomanshus_mcp.server --port 8080
+
+# stdio transport
+python -m ra_mcp_sjomanshus_mcp.server --stdio
+```
+
+## Dependencies
+
+- Internal: `ra-mcp-sjomanshus-lib` (which depends on `ra-mcp-common`)
+- External: `fastmcp`
+
+## Part of ra-mcp
+
+Composed into the root server alongside the other dataset modules. Tools are registered as bare names (`search_liggare`, `search_matrikel`) and get namespaced as `<module>:<tool>` in the composed server. See the [docs site](https://ai-riksarkivet.github.io/ra-mcp/) for full project documentation.

--- a/packages/specialsok-mcp/README.md
+++ b/packages/specialsok-mcp/README.md
@@ -1,0 +1,103 @@
+# ra-mcp-specialsok-mcp
+
+MCP tools for Specialsök datasets (flygvapen, fångrullor, kurhuset, press, video).
+
+## Overview
+
+Thin MCP wrapper around `ra-mcp-specialsok-lib`. Registers five FastMCP tools — `search_flygvapen`, `search_fangrullor`, `search_kurhuset`, `search_press`, and `search_video` — each running full-text search over its own table in a local LanceDB copy of the Riksarkivet Specialsök datasets. Tools are registered as bare names and get namespaced as `<module>:<tool>` when composed into the root server.
+
+## MCP Tools
+
+### `search_flygvapen`
+
+Search Swedish military aviation accidents (Flygvapenhaverier) with aircraft types, crash sites, and summaries.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across aviation accident records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum records per query |
+| `fpl_typ` | str \| None | None | Filter: aircraft type (case-insensitive substring, e.g. `J 35`) |
+| `research_context` | str \| None | None | Research goal summary (logging only) |
+
+### `search_fangrullor`
+
+Search Östersund prison records (Fångrullor) — inmates with names, ages, crimes, and home parishes.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across prison records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum records per query |
+| `brott` | str \| None | None | Filter: crime type (case-insensitive substring, e.g. `stöld` for theft) |
+| `research_context` | str \| None | None | Research goal summary (logging only) |
+
+### `search_kurhuset`
+
+Search hospital patient records (Kurhuset) with diagnoses, treatments, and outcomes.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across hospital patient records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum records per query |
+| `sjukdom` | str \| None | None | Filter: disease name (case-insensitive substring, e.g. `syfilis`) |
+| `research_context` | str \| None | None | Research goal summary (logging only) |
+
+### `search_press`
+
+Search Swedish government press conferences (Presskonferenser) with titles and content descriptions.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across press conference records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum records per query |
+| `aar` | str \| None | None | Filter: year (case-insensitive substring, e.g. `2005`) |
+| `research_context` | str \| None | None | Research goal summary (logging only) |
+
+### `search_video`
+
+Search Swedish video rental stores (Videobutiker) across Sweden.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across video store records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50, ...) |
+| `limit` | int | 25 | Maximum records per query |
+| `laen` | str \| None | None | Filter: county name (case-insensitive substring, e.g. `Stockholm`) |
+| `kommun` | str \| None | None | Filter: municipality name (case-insensitive substring) |
+| `research_context` | str \| None | None | Research goal summary (logging only) |
+
+## Components
+
+- **tools.py**: FastMCP server setup, instructions, and registration of all five tools
+- **flygvapen_tool.py**: `search_flygvapen` tool (Flygvapenhaverier table)
+- **fangrullor_tool.py**: `search_fangrullor` tool (Fångrullor table)
+- **kurhuset_tool.py**: `search_kurhuset` tool (Kurhuset table)
+- **press_tool.py**: `search_press` tool (Presskonferenser table)
+- **video_tool.py**: `search_video` tool (Videobutiker table)
+- **formatter.py**: Formats each dataset's search results for LLM consumption
+- **server.py**: Standalone entry point for isolated dev/testing
+
+## Standalone Usage
+
+```bash
+# HTTP transport (default, port 3012)
+python -m ra_mcp_specialsok_mcp.server
+
+# HTTP transport on a custom port
+python -m ra_mcp_specialsok_mcp.server --port 8080
+
+# stdio transport
+python -m ra_mcp_specialsok_mcp.server --stdio
+```
+
+## Dependencies
+
+- Internal: `ra-mcp-specialsok-lib` (which depends on `ra-mcp-common`)
+- External: `fastmcp`
+
+## Part of ra-mcp
+
+Composed into the root server alongside the other dataset modules. Tools are registered as bare names (`search_flygvapen`, `search_fangrullor`, `search_kurhuset`, `search_press`, `search_video`) and get namespaced as `<module>:<tool>` in the composed server. See the [docs site](https://ai-riksarkivet.github.io/ra-mcp/) for full project documentation.

--- a/packages/suffrage-mcp/README.md
+++ b/packages/suffrage-mcp/README.md
@@ -1,0 +1,63 @@
+# ra-mcp-suffrage-mcp
+
+MCP tools for Swedish women's suffrage records (Rösträtt & FKPR).
+
+## Overview
+
+Thin MCP wrapper around `ra-mcp-suffrage-lib`. Registers two FastMCP tools — `search_rostratt` and `search_fkpr` — each running LanceDB full-text search over a women's suffrage dataset and returning LLM-friendly formatted output. The tools are registered as bare names and get namespaced as `suffrage:<tool>` when composed into the root server.
+
+## MCP Tools
+
+### `search_rostratt`
+
+Search women's suffrage petition signatures 1913-1914 — 29,000 names from 5 counties. Returns signer name, title, occupation, address, town, county, and monetary contributions.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across Rösträtt petition records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50...) |
+| `limit` | int | 25 | Maximum number of records to return per query |
+| `lan` | str \| None | None | Optional filter: county name (case-insensitive substring match) |
+| `ortens_namn` | str \| None | None | Optional filter: town name (case-insensitive substring match) |
+| `research_context` | str \| None | None | Brief summary of the research goal (logging only) |
+
+### `search_fkpr`
+
+Search Gothenburg FKPR suffrage association members 1911-1920 — 1,700 women. Returns name, title/occupation, address, and years of membership.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across FKPR membership records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50...) |
+| `limit` | int | 25 | Maximum number of records to return per query |
+| `research_context` | str \| None | None | Brief summary of the research goal (logging only) |
+
+## Components
+
+- **tools.py**: FastMCP server setup, instructions, and tool registration
+- **rostratt_tool.py**: `search_rostratt` tool registration with lazy LanceDB connection
+- **fkpr_tool.py**: `search_fkpr` tool registration with lazy LanceDB connection
+- **formatter.py**: Formats Rösträtt and FKPR results for LLM consumption
+- **server.py**: Standalone entry point for isolated dev/testing
+
+## Standalone Usage
+
+```bash
+# HTTP transport (default, port 3011)
+python -m ra_mcp_suffrage_mcp.server
+
+# HTTP transport on a custom port
+python -m ra_mcp_suffrage_mcp.server --port 3011
+
+# stdio transport
+python -m ra_mcp_suffrage_mcp.server --stdio
+```
+
+## Dependencies
+
+- Internal: `ra-mcp-suffrage-lib` (depends on `ra-mcp-common`)
+- External: `fastmcp`
+
+## Part of ra-mcp
+
+Composed into the root server alongside the other dataset modules. Tools are registered as bare names (`search_rostratt`, `search_fkpr`) and get namespaced as `suffrage:<tool>` in the composed server. See the [docs site](https://ai-riksarkivet.github.io/ra-mcp/) for full project documentation.

--- a/packages/tora-mcp/README.md
+++ b/packages/tora-mcp/README.md
@@ -1,0 +1,55 @@
+# ra-mcp-tora-mcp
+
+MCP tools for TORA — geocode historical Swedish places.
+
+## Overview
+
+Thin MCP wrapper around `ra-mcp-tora-lib`. Registers a single FastMCP tool — `search_tora` — that geocodes historical Swedish places by querying TORA (Topografiskt register på Riksarkivet) over its SPARQL endpoint, enriching results with linked historical images and geometrical maps, and returning LLM-friendly formatted output. The tool is registered as a bare name and gets namespaced as `tora:<tool>` when composed into the root server.
+
+## MCP Tools
+
+### `search_tora`
+
+Geocode historical Swedish places using TORA. Returns WGS84 coordinates, parish, municipality, county, and province for 51,000 settlements. Many places include linked historical Suecia Antiqua engravings (1600s) from KB, as well as linked geometrical maps (1630-1700) used as coordinate sources.
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `name` | str | *(required)* | Place name to search for (exact match, e.g. 'Kerstinbo', 'Abbekås') |
+| `parish` | str \| None | None | Optional parish name to disambiguate (case-insensitive substring match) |
+| `county` | str \| None | None | Optional county/län to disambiguate (case-insensitive substring match) |
+
+## Components
+
+- **tools.py**: FastMCP server setup, instructions, and tool registration
+- **tora_tool.py**: `search_tora` tool registration; constructs a `ToraClient` per call
+- **formatter.py**: Formats TORA place results for LLM consumption
+- **server.py**: Standalone entry point for isolated dev/testing
+
+The underlying `ra-mcp-tora-lib` provides:
+
+- **client.py**: `ToraClient` — async SPARQL client that searches settlements and enriches them with linked images and maps
+- **geocode.py**: `geocode()` convenience helper returning a `(lat, lon)` tuple for the best match
+- **models.py**: Pydantic models (`ToraPlace`, `ToraImage`, `ToraMapSource`)
+- **config.py**: SPARQL endpoint (`https://tora.entryscape.net/store/sparql`) and geocode cache size
+
+## Standalone Usage
+
+```bash
+# HTTP transport (default, port 3020)
+python -m ra_mcp_tora_mcp.server
+
+# HTTP transport on a custom port
+python -m ra_mcp_tora_mcp.server --port 3020
+
+# stdio transport
+python -m ra_mcp_tora_mcp.server --stdio
+```
+
+## Dependencies
+
+- Internal: `ra-mcp-tora-lib` (uses `httpx` for SPARQL queries)
+- External: `fastmcp`
+
+## Part of ra-mcp
+
+Composed into the root server alongside the other dataset modules. The tool is registered as a bare name (`search_tora`) and gets namespaced as `tora:<tool>` in the composed server. See the [docs site](https://ai-riksarkivet.github.io/ra-mcp/) for full project documentation.

--- a/packages/tui/README.md
+++ b/packages/tui/README.md
@@ -28,6 +28,7 @@ ra tui "Stockholm"    # Search on launch
 | `Enter` | Submit search / Open selected item |
 | `Escape` | Go back / Clear search |
 | `m` | Toggle search mode (Transcribed / Metadata) |
+| `d` | Open the highlighted result as a Document (search screen) |
 | `n` / `p` | Next / Previous page of results |
 | `o` | Open in browser (works on all screens) |
 | `y` | Copy reference code to clipboard |
@@ -46,7 +47,7 @@ ra tui "Stockholm"    # Search on launch
 
 ## Dependencies
 
-- Internal: `ra-mcp-search`, `ra-mcp-browse`
+- Internal: `ra-mcp-search-lib`, `ra-mcp-browse-lib`
 - External: `textual`, `typer`
 
 ## Part of ra-mcp

--- a/packages/viewer-mcp/README.md
+++ b/packages/viewer-mcp/README.md
@@ -4,61 +4,86 @@ Interactive document viewer MCP App with zoomable images and text layer overlays
 
 ## Overview
 
-An MCP App that renders an interactive document viewer directly inside the MCP host (Claude, ChatGPT, etc.). Uses FastMCP's `AppConfig` to serve a self-contained HTML/JS viewer that displays high-resolution page images with optional ALTO/PAGE XML text layer overlays for search, selection, and accessibility.
+An MCP App that renders an interactive document viewer directly inside the MCP host (Claude, ChatGPT, etc.). Uses FastMCP's `AppConfig` to serve a self-contained HTML/JS viewer that displays high-resolution page images with optional ALTO/PAGE XML text layer overlays for search, highlighting, and accessibility.
 
-The viewer supports lazy-loading pages and thumbnails via app-visible tools that the UI calls on demand.
+There are several entry points depending on what you have: a reference code (`view_document`), a IIIF manifest URL (`view_manifest`), a `bild_id` image identifier (`view_bild`), or raw paired image/text-layer URLs (`view_document_urls`). Once a viewer is open, a set of `viewer_*` tools mutate the live view (navigate pages, change the highlight, reopen fullscreen) instead of opening a new one. The viewer lazy-loads pages, thumbnails, and per-page search results via app-visible tools it calls on demand. View state is persisted in an async key-value store so the UI can poll for LLM-initiated changes.
 
 ## MCP Tools
 
-### `view_document` (user-visible)
+### Open the viewer (user-visible)
 
-Entry point for displaying document pages. Returns page 1 transcription to the model and renders the viewer UI.
+| Tool | Key parameters | Purpose |
+|------|----------------|---------|
+| `view_document` | `reference_code`, `pages`, `highlight_term?`, `max_pages=20` | Resolve a reference code + page spec (same as `browse_document`) and open the viewer |
+| `view_document_urls` | `image_urls`, `text_layer_urls`, `document_info?`, `highlight_term?` | Open the viewer from raw paired image and ALTO/PAGE XML URLs (use `""` for pages without transcription) |
+| `view_manifest` | `manifest_url`, `highlight_term?`, `max_pages=20`, `document_info?` | Open the viewer from a IIIF manifest URL (e.g. SDHK/MPO results) |
+| `view_bild` | `bild_ids`, `highlight_term?` | Open the viewer by `bild_id` image identifier(s) (e.g. `C0056829_00001` from DDS church records) |
 
-| Parameter | Type | Default | Description |
-|-----------|------|---------|-------------|
-| `image_urls` | list[str] | *(required)* | One image URL per page |
-| `text_layer_urls` | list[str] | *(required)* | One ALTO/PAGE XML URL per page (paired 1:1 with `image_urls`). Use `""` for pages without transcription. |
-| `metadata` | list[str] \| None | None | Per-page labels (e.g., archive reference codes) |
+### Control an open viewer (user-visible)
 
-Both lists must have the same length.
+| Tool | Key parameters | Purpose |
+|------|----------------|---------|
+| `viewer_navigate` | `reference_code`, `pages`, `highlight_term?`, `max_pages=20` | Replace the open viewer's pages with new ones by reference code |
+| `viewer_navigate_urls` | `image_urls`, `text_layer_urls`, `highlight_term?` | Replace the open viewer's pages with new raw URLs |
+| `viewer_go_to_page` | `page` | Scroll the open viewer to a page (does not reload pages) |
+| `viewer_set_highlight` | `highlight_term` | Update (or clear) the search highlight in the open viewer |
+| `viewer_reopen` | *(none)* | Bring the open viewer back to fullscreen |
 
-### `load_page` (app-visible only)
+### Used by the viewer UI (app-visible only)
 
-Fetches a single page on demand — called by the viewer UI for pagination.
-
-### `load_thumbnails` (app-visible only)
-
-Batch-fetches thumbnail images — called by the viewer UI for the thumbnail strip.
+| Tool | Key parameters | Purpose |
+|------|----------------|---------|
+| `get_viewer_state` | `view_id` | Poll current viewer state by view id |
+| `load_page` | `image_url`, `text_layer_url`, `page_index` | Fetch a single page (image + parsed text layer) for pagination |
+| `load_thumbnails` | `image_urls`, `page_indices` | Batch-fetch and resize thumbnails for the thumbnail strip |
+| `search_all_pages` | `text_layer_urls`, `term` | Search a term across all pages, returning per-page match counts |
 
 ## Architecture
 
-This is an **MCP App** — it uses FastMCP's `AppConfig` and `ui://` resources:
+This is an **MCP App** — it uses FastMCP's `AppConfig` and a `ui://` resource:
 
 ```
-Model calls view_document
+Model calls view_document / view_manifest / view_bild / view_document_urls
     |
     v
-Tool returns: text summary (for model) + structured content (for UI)
+Tool resolves pages, persists ViewerState, returns text summary (model) + structured content (UI)
     |
     v
 MCP host renders ui://document-viewer/mcp-app.html
     |
     v
-Viewer UI calls load_page / load_thumbnails via callServerTool
+Viewer UI calls load_page / load_thumbnails / search_all_pages / get_viewer_state on demand
 ```
 
-The HTML viewer is built from `src/ra_mcp_viewer_mcp/dist/mcp-app.html` and served as a `ui://` resource.
+The HTML viewer is built into `src/ra_mcp_viewer_mcp/dist/mcp-app.html` and served as the `ui://document-viewer/mcp-app.html` resource.
 
 ## Components
 
-- **tools.py**: Tool and resource registrations (`view_document`, `load_page`, `load_thumbnails`, UI resource)
-- **fetchers.py**: Async functions for fetching page data, text layers, and thumbnail images
-- **parser.py**: ALTO/PAGE XML parser
-- **models.py**: Data models
+- **tools.py**: Tool and resource registrations (all `view_*`, `viewer_*`, and app-visible tools, plus the UI resource)
+- **resolve.py**: Resolves reference codes, IIIF manifests, and `bild_id`s into image/text-layer URLs; validates URL pairs
+- **fetchers.py**: Async functions for fetching page data, parsing text layers, and building thumbnail data URLs
+- **formatter.py**: Builds the text summaries and `ToolResult` helpers returned to the model
+- **models.py**: `ViewerState` and related data models
+- **state.py**: Async key-value store for viewer state (`get_state`, `put_state`, `get_active_state`)
+- **server.py**: Standalone entry point for isolated dev/testing
+
+## Standalone Usage
+
+```bash
+# HTTP transport (default, port 3001)
+python -m ra_mcp_viewer_mcp.server
+
+# HTTP transport on a custom port
+python -m ra_mcp_viewer_mcp.server --port 3001
+
+# stdio transport
+python -m ra_mcp_viewer_mcp.server --stdio
+```
 
 ## Dependencies
 
-- External: `fastmcp`
+- Internal: `ra-mcp-browse-lib`, `ra-mcp-iiif-lib`, `ra-mcp-xml`
+- External: `httpx[http2]`, `fastmcp`, `pillow`, `py-key-value-aio[memory]`
 
 ## Part of ra-mcp
 

--- a/packages/wincars-mcp/README.md
+++ b/packages/wincars-mcp/README.md
@@ -1,0 +1,52 @@
+# ra-mcp-wincars-mcp
+
+MCP tools for Norrland vehicle registration records (Wincars) search.
+
+## Overview
+
+Thin MCP wrapper around `ra-mcp-wincars-lib`. Registers a single FastMCP tool — `search_wincars` — that runs LanceDB full-text search over the Norrland vehicle register and returns LLM-friendly formatted output. The tool is registered as a bare name and gets namespaced as `wincars:<tool>` when composed into the root server.
+
+## MCP Tools
+
+### `search_wincars`
+
+Search the Norrland vehicle register 1916-1972 — 1.5 million vehicles across 5 northern Swedish counties (Gävleborg, Jämtland, Norrbotten, Västerbotten, Västernorrland). Returns registration number, vehicle type, make/model, year, chassis/engine numbers, registration/deregistration dates, domicile, and status (active/written off/scrapped).
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `keyword` | str | *(required)* | Search term for full-text search across vehicle registration records |
+| `offset` | int | 0 | Pagination start position (0, 25, 50...) |
+| `limit` | int | 25 | Maximum number of records to return per query |
+| `typ` | str \| None | None | Optional filter: vehicle type code (e.g. 'PB'=car, 'MC'=motorcycle, 'LB'=truck, 'SL'=trailer, 'TR'=tractor, 'BS'=bus) |
+| `hemvist` | str \| None | None | Optional filter: domicile/location (case-insensitive substring match) |
+| `fabrikat` | str \| None | None | Optional filter: make/manufacturer (case-insensitive substring match) |
+| `research_context` | str \| None | None | Brief summary of the research goal (logging only) |
+
+## Components
+
+- **tools.py**: FastMCP server setup, instructions, and tool registration
+- **wincars_tool.py**: `search_wincars` tool registration with lazy LanceDB connection
+- **formatter.py**: Formats Wincars results for LLM consumption
+- **server.py**: Standalone entry point for isolated dev/testing
+
+## Standalone Usage
+
+```bash
+# HTTP transport (default, port 3014)
+python -m ra_mcp_wincars_mcp.server
+
+# HTTP transport on a custom port
+python -m ra_mcp_wincars_mcp.server --port 3014
+
+# stdio transport
+python -m ra_mcp_wincars_mcp.server --stdio
+```
+
+## Dependencies
+
+- Internal: `ra-mcp-wincars-lib` (depends on `ra-mcp-common`)
+- External: `fastmcp`
+
+## Part of ra-mcp
+
+Composed into the root server alongside the other dataset modules. The tool is registered as a bare name (`search_wincars`) and gets namespaced as `wincars:<tool>` in the composed server. See the [docs site](https://ai-riksarkivet.github.io/ra-mcp/) for full project documentation.

--- a/plugins/ra-mcp-tools/.claude-plugin/plugin.json
+++ b/plugins/ra-mcp-tools/.claude-plugin/plugin.json
@@ -5,5 +5,5 @@
     "name": "AI-Riksarkivet"
   },
   "repository": "https://github.com/AI-Riksarkivet/ra-mcp",
-  "license": "MIT"
+  "license": "Apache-2.0"
 }

--- a/plugins/ra-mcp-tools/README.md
+++ b/plugins/ra-mcp-tools/README.md
@@ -1,6 +1,6 @@
 # Riksarkivet Tools Plugin for Claude Code
 
-A Claude Code plugin providing skills for archive research workflows — search strategy, research methodology, HTR transcription, document viewing, and file uploads.
+A Claude Code plugin providing skills for archive research workflows — search strategy, research methodology, archival record knowledge, HTR transcription, document and PDF viewing, Label Studio feedback, and file uploads.
 
 ## Installation
 
@@ -24,6 +24,12 @@ Research methodology guide. Covers research integrity rules (never fabricate dat
 
 **Trigger phrases**: browse document, read pages, translate old Swedish, cite sources, present findings, research methodology
 
+### `/archival-guide`
+
+Swedish archival record-type and administrative-history guide. Maps research topics to the correct *Förvaltningshistorik* chapters (served as MCP resources) so you know what record types exist, which authorities created them, and where to find them — court records, church records, folkbokföring, bouppteckning, dombok, husförhörslängd, mantalslängd, military, tax, and prison records.
+
+**Trigger phrases**: what records exist, which archive, document types, court records, church records, folkbokföring, bouppteckning, dombok, husförhörslängd, mantalslängd, Swedish administrative history
+
 ### `/htr-transcription`
 
 HTR workflow guide. Covers the full pipeline: determine image source, batch all images into a single `htr_transcribe` call, present results as an inline artifact with the interactive viewer. Documents language options (Swedish, Norwegian, English, medieval), layout modes, export formats (ALTO XML, PAGE XML, JSON), and custom HTRflow YAML pipelines.
@@ -32,9 +38,21 @@ HTR workflow guide. Covers the full pipeline: determine image source, batch all 
 
 ### `/view_document-guide`
 
-Document viewer guide. Covers the `view_document` tool's required arguments (`image_urls` paired 1:1 with `text_layer_urls`), optional metadata, and common mistakes (mismatched list lengths, non-public URLs, forgetting empty strings for missing text layers).
+Document viewer guide. Covers the three viewer entry points and how to choose between them: `view_document` (when you have a Riksarkivet reference code), `view_manifest` (when you have a IIIF manifest URL, e.g. from SDHK/MPO search), and `view_document_urls` (when you already have raw image and text-layer XML URLs).
 
-**Trigger phrases**: view document, display pages, show document, document viewer
+**Trigger phrases**: view document, display pages, show document, document viewer, view manifest
+
+### `/pdf-guide`
+
+Riksarkivet PDF guide reader. Covers searching and reading the archival PDF guides (medieval Sweden, governance 1520–1920, Sami history) via `search_guides`, `read_pdf_page`, `display_pdf`, and `search_pdf`, returning section-level references with page numbers for citation.
+
+**Trigger phrases**: Swedish history, archives, medieval charters, governance, Sami, open PDF guide, search PDF guides
+
+### `/feedback-ls`
+
+Label Studio feedback workflow. Covers sending document pages to Label Studio for human annotation via `import_to_label_studio` — both ALTO pre-annotated tasks and image-only blank tasks, with transcription/segmentation feedback choices and optional assignment.
+
+**Trigger phrases**: feedback, label studio, annotation, review transcription, quality check, human review, segmentation feedback, transcription feedback
 
 ### `/upload-files`
 


### PR DESCRIPTION
Bring documentation in line with the code after the search/browse -> *-lib rename, the extracted xml/iiif/oai-pmh client libs, the async httpx HTTP client, and the 15 optional dataset modules.

- CLAUDE.md: rewrite architecture/package tree, paths, module registration pattern, API endpoints, version pins; fix SearchAPI->SearchClient and urllib->httpx residuals
- docs/: cover all 21 modules and the local LanceDB datasets, list 8 skills, add make build-ui step, fix cov/test paths and telemetry span names
- install: use ra-mcp[cli,tui] so the documented ra subcommands work
- package READMEs: fix common/search/browse/viewer/label/guide/htr/tui and the plugin (license MIT->Apache-2.0); add READMEs for pdf-mcp and the 14 data-source *-mcp packages